### PR TITLE
fix: prevent panic when truncating UTF-8 string at non-char boundary

### DIFF
--- a/crates/channels/src/feishu.rs
+++ b/crates/channels/src/feishu.rs
@@ -366,7 +366,7 @@ impl FeishuChannel {
                                 debug!(method = frame.method, msg_type = %msg_type, payload_len = frame.payload.len(), "Feishu data frame");
                                 match std::str::from_utf8(&frame.payload) {
                                     Ok(text) => {
-                                        info!(payload = %&text[..text.len().min(500)], "Feishu raw event payload");
+                                        info!(payload = %text.chars().take(500).collect::<String>(), "Feishu raw event payload");
                                         // Send ACK frame
                                         let ack = Frame {
                                             seq_id: frame.seq_id,


### PR DESCRIPTION
The previous implementation used byte slicing `&text[..500]` which panics when the cutoff point falls inside a multi-byte UTF-8 character (e.g., Chinese characters). Switch to character-aware truncation using `chars().take(500).collect()` to safely handle internationalized text.

Fixes panic:
```
thread 'tokio-runtime-worker' panicked at feishu.rs:369:63:
byte index 500 is not a char boundary; it is inside '后' (bytes 499..502)
```