### PR TITLE
fix: set max iterations per tool.

### DIFF
--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -2087,16 +2087,22 @@ impl AgentRuntime {
             .defaults
             .max_tool_iterations
             .clamp(1, 30);
+        let tools_max_iterations = self
+            .config
+            .agents
+            .defaults
+            .max_tool_iterations_by_tool
+            .clone();
+        let mut tool_call_counts: HashMap<String, u32> = HashMap::new();
+        let mut over_iteration: bool = false;
         let mut current_messages = messages;
-        let mut final_response = String::new();
         let mut trace_messages = Vec::new();
 
-        for iteration in 0..max_iterations {
+        let final_response = loop {
             let response = self.chat_with_provider(&current_messages, &tools).await?;
 
             if response.tool_calls.is_empty() {
-                final_response = response.content.unwrap_or_default();
-                break;
+                break response.content.unwrap_or_default();
             }
 
             let assistant_tool_call = ChatMessage {
@@ -2116,8 +2122,28 @@ impl AgentRuntime {
                         &tool_call.name,
                         &allowed_tool_names,
                     ) {
-                        self.execute_tool_call(&tool_call, msg, active_skill_dir.clone())
-                            .await
+                        let max_iterations = tools_max_iterations
+                            .get(&tool_call.name)
+                            .copied()
+                            .unwrap_or(max_iterations);
+                        let count = tool_call_counts.entry(tool_call.name.clone()).or_insert(0);
+
+                        *count += 1;
+                        if *count > max_iterations {
+                            over_iteration = true;
+                            serde_json::json!({
+                                "error": format!(
+                                    "Tool '{}' execeeded max call limit ({}).",
+                                    tool_call.name, max_iterations
+                                ),
+                                "tool": tool_call.name,
+                                "hint": "Reduce repeated tool calls or adjust maxToolIterationsByTool."
+                            })
+                            .to_string()
+                        } else {
+                            self.execute_tool_call(&tool_call, msg, active_skill_dir.clone())
+                                .await
+                        }
                     } else {
                         serde_json::json!({
                             "error": format!(
@@ -2135,19 +2161,19 @@ impl AgentRuntime {
                 trace_messages.push(tool_message);
             }
 
-            if iteration == max_iterations - 1 {
+            if over_iteration {
                 let mut final_messages = current_messages.clone();
                 final_messages.push(ChatMessage::user(
                     "请基于以上技能上下文和工具结果，直接给出最终答案。不要再调用任何工具。",
                 ));
-                final_response = self
+                let final_response = self
                     .chat_with_provider(&final_messages, &[])
                     .await?
                     .content
                     .unwrap_or_default();
-                break;
+                break final_response;
             }
-        }
+        };
 
         let final_response = strip_fake_tool_calls(final_response.trim());
         Ok(PromptSkillLoopOutput {
@@ -2469,7 +2495,7 @@ impl AgentRuntime {
         current_messages: &[ChatMessage],
         tools: &[serde_json::Value],
         msg: &InboundMessage,
-        iteration: u32,
+        iteration: &HashMap<String, u32>,
         saw_rate_limit_this_turn: &mut bool,
     ) -> std::result::Result<LLMResponse, blockcell_core::Error> {
         let max_retries = self.config.agents.defaults.llm_max_retries;
@@ -2481,7 +2507,10 @@ impl AgentRuntime {
                 let delay_ms = base_delay_ms * (1u64 << (attempt - 1).min(4));
                 warn!(
                     attempt,
-                    max_retries, delay_ms, iteration, "Retrying LLM call after transient error"
+                    max_retries,
+                    delay_ms,
+                    ?iteration,
+                    "Retrying LLM call after transient error"
                 );
                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
             }
@@ -2500,7 +2529,9 @@ impl AgentRuntime {
                     if attempt > 0 {
                         info!(
                             attempt,
-                            iteration, pool_idx, "LLM stream call succeeded after retry"
+                            ?iteration,
+                            pool_idx,
+                            "LLM stream call succeeded after retry"
                         );
                     }
                     let mut accumulated_content = String::new();
@@ -2675,7 +2706,7 @@ impl AgentRuntime {
                 }
                 Err(e) => {
                     let err_str = format!("{}", e);
-                    warn!(error = %err_str, attempt, max_retries, iteration, pool_idx, "LLM stream call failed");
+                    warn!(error = %err_str, attempt, max_retries, ?iteration, pool_idx, "LLM stream call failed");
                     let call_result = ProviderPool::classify_error(&err_str);
                     if matches!(&call_result, CallResult::RateLimit) {
                         *saw_rate_limit_this_turn = true;
@@ -3021,6 +3052,14 @@ impl AgentRuntime {
 
         // Main loop with max iterations
         let max_iterations = self.config.agents.defaults.max_tool_iterations;
+        let tools_max_iterations = self
+            .config
+            .agents
+            .defaults
+            .max_tool_iterations_by_tool
+            .clone();
+        let mut tool_call_counts: HashMap<String, u32> = HashMap::new();
+        let mut over_iteration: bool = false;
         let mut current_messages = messages;
         let mut final_response = String::new();
         let mut message_tool_sent_media = false;
@@ -3035,10 +3074,10 @@ impl AgentRuntime {
         // Only dynamic supplement (below) mutates the `tools` vec — no redundant reload.
         let mut _schema_cache_dirty = false;
 
-        for iteration in 0..max_iterations {
-            debug!(iteration, "LLM call iteration");
+        loop {
+            debug!(iteration = ?tool_call_counts, "LLM call iteration");
             debug!(
-                iteration,
+                iteration = ?tool_call_counts,
                 current_messages_len = current_messages.len(),
                 tool_schema_count = tools.len(),
                 "LLM loop state"
@@ -3047,7 +3086,7 @@ impl AgentRuntime {
             if should_throttle_next_tool_round {
                 let delay = tool_round_throttle_delay(saw_rate_limit_this_turn);
                 info!(
-                    iteration,
+                    iteration = ?tool_call_counts,
                     delay_ms = delay.as_millis() as u64,
                     saw_rate_limit_this_turn,
                     "Throttling next LLM call after tool round"
@@ -3063,7 +3102,7 @@ impl AgentRuntime {
                     &current_messages,
                     &tools,
                     &msg,
-                    iteration,
+                    &tool_call_counts,
                     &mut saw_rate_limit_this_turn,
                 )
                 .await;
@@ -3073,7 +3112,7 @@ impl AgentRuntime {
                 Ok(r) => r,
                 Err(e) => {
                     let max_retries = self.config.agents.defaults.llm_max_retries;
-                    warn!(error = %e, iteration, retries = max_retries, "LLM call failed after all retries");
+                    warn!(error = %e, iteration = ?tool_call_counts, retries = max_retries, "LLM call failed after all retries");
                     final_response = llm_exhausted_error(max_retries, &e);
                     if let Some(evo_service) = self.context_builder.evolution_service() {
                         let _ = evo_service
@@ -3206,7 +3245,27 @@ impl AgentRuntime {
                     }
                     let tool_timer = ScopedTimer::new();
                     let result = if tool_names.iter().any(|allowed| allowed == &tool_call.name) {
-                        self.execute_tool_call(tool_call, &msg, None).await
+                        let max_iterations = tools_max_iterations
+                            .get(&tool_call.name)
+                            .copied()
+                            .unwrap_or(max_iterations);
+                        let count = tool_call_counts.entry(tool_call.name.clone()).or_insert(0);
+
+                        *count += 1;
+                        if *count > max_iterations {
+                            over_iteration = true;
+                            serde_json::json!({
+                                "error": format!(
+                                    "Tool '{}' execeeded max call limit ({}).",
+                                    tool_call.name, max_iterations
+                                ),
+                                "tool": tool_call.name,
+                                "hint": "Reduce repeated tool calls or adjust maxToolIterationsByTool."
+                            })
+                            .to_string()
+                        } else {
+                            self.execute_tool_call(tool_call, &msg, None).await
+                        }
                     } else {
                         scoped_tool_denied_result(&tool_call.name)
                     };
@@ -3386,7 +3445,7 @@ impl AgentRuntime {
                     history.push(tool_msg);
                 }
 
-                if wants_forced_answer && iteration + 1 < max_iterations {
+                if wants_forced_answer && !over_iteration {
                     if !web_search_thin_results.is_empty() {
                         // Thin results: guide LLM to fetch actual page content instead of giving up
                         let urls_hint = web_search_thin_results
@@ -3437,7 +3496,7 @@ impl AgentRuntime {
                     );
                 }
 
-                if iteration + 1 < max_iterations && !short_circuit_after_tools {
+                if !over_iteration && !short_circuit_after_tools {
                     should_throttle_next_tool_round = true;
                 }
 
@@ -3446,10 +3505,12 @@ impl AgentRuntime {
                     break;
                 }
 
-                if iteration == max_iterations - 1 {
+                if over_iteration {
                     warn!(
-                        iteration,
-                        max_iterations, "Reached max iterations; forcing a final no-tools answer"
+                        iteration = ?tool_call_counts,
+                        max_iterations,
+                        ?tools_max_iterations,
+                        "Reached max iterations; forcing a final no-tools answer"
                     );
                     let mut final_messages = current_messages.clone();
                     final_messages.push(ChatMessage::user(

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -127,6 +127,9 @@ pub struct AgentDefaults {
     pub temperature: f32,
     #[serde(default = "default_max_tool_iterations")]
     pub max_tool_iterations: u32,
+    /// Per-tool max iterations. If a tool name is not present, use max_tool_iterations as default.
+    #[serde(default)]
+    pub max_tool_iterations_by_tool: HashMap<String, u32>,
     #[serde(default = "default_llm_max_retries")]
     pub llm_max_retries: u32,
     #[serde(default = "default_llm_retry_delay_ms")]
@@ -202,6 +205,7 @@ impl Default for AgentDefaults {
             max_tokens: default_max_tokens(),
             temperature: default_temperature(),
             max_tool_iterations: default_max_tool_iterations(),
+            max_tool_iterations_by_tool: HashMap::new(),
             llm_max_retries: default_llm_max_retries(),
             llm_retry_delay_ms: default_llm_retry_delay_ms(),
             max_context_tokens: default_max_context_tokens(),
@@ -310,6 +314,8 @@ pub struct AgentProfileConfig {
     #[serde(default)]
     pub max_tool_iterations: Option<u32>,
     #[serde(default)]
+    pub max_tool_iterations_by_tool: HashMap<String, u32>,
+    #[serde(default)]
     pub llm_max_retries: Option<u32>,
     #[serde(default)]
     pub llm_retry_delay_ms: Option<u64>,
@@ -342,6 +348,7 @@ impl Default for AgentProfileConfig {
             max_tokens: None,
             temperature: None,
             max_tool_iterations: None,
+            max_tool_iterations_by_tool: HashMap::new(),
             llm_max_retries: None,
             llm_retry_delay_ms: None,
             max_context_tokens: None,
@@ -1785,6 +1792,9 @@ impl Config {
             }
             if let Some(max_tool_iterations) = agent.max_tool_iterations {
                 defaults.max_tool_iterations = max_tool_iterations;
+            }
+            if !agent.max_tool_iterations_by_tool.is_empty() {
+                defaults.max_tool_iterations_by_tool = agent.max_tool_iterations_by_tool.clone();
             }
             if let Some(llm_max_retries) = agent.llm_max_retries {
                 defaults.llm_max_retries = llm_max_retries;


### PR DESCRIPTION
- new configuration maxToolIterationsByTool, usage: {"maxToolIterationsByTool": {"exec": 30, "read_file": 40}}.
- use 'maxToolIterations' as default if maxToolIterationsByTool not configured.
- break if one of the tools call exceed the limitation.