### PR TITLE
fix: 修复学习协调器/SQL注入/配置传播/技能索引/记忆安全相关bug:

### DIFF
--- a/crates/agent/src/forked/can_use_tool.rs
+++ b/crates/agent/src/forked/can_use_tool.rs
@@ -692,15 +692,16 @@ fn is_auto_mem_path(path: &str, memory_dir: &Path) -> bool {
                 }
             }
         }
-        // 路径以 memory_dir 开头但文件和父目录都不存在，保守拒绝。
-        // 创建新文件时父目录必须已存在并通过 canonicalize 验证。
+        // 路径以 memory_dir 开头但文件和父目录都不存在。
+        // 如果没有路径遍历组件，且 memory_dir 本身存在，允许创建新文件。
         if path
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
         {
             return false;
         }
-        return false;
+        // memory_dir 必须存在才能允许在其下创建新文件
+        return memory_dir.exists();
     }
 
     // 路径不以 memory_dir 开头，保守拒绝（安全优先）

--- a/crates/agent/src/ghost_background_review.rs
+++ b/crates/agent/src/ghost_background_review.rs
@@ -47,8 +47,9 @@ pub async fn run_background_review_for_episode(
     paths: &Paths,
     provider_pool: Arc<ProviderPool>,
     episode_id: &str,
+    config: &Config,
+    ledger: &GhostLedger,
 ) -> Result<GhostBackgroundReviewOutcome> {
-    let ledger = GhostLedger::open(&paths.ghost_ledger_db())?;
     let Some(episode) = ledger.get_episode(episode_id)? else {
         return Err(Error::NotFound(format!(
             "Ghost episode not found for background review: {}",
@@ -62,7 +63,7 @@ pub async fn run_background_review_for_episode(
     let Some((provider_idx, provider)) = provider_pool.acquire() else {
         metrics.record_review_failed();
         return record_failed_review_run(
-            &ledger,
+            ledger,
             episode_id,
             "No provider available for ghost background review",
             None,
@@ -70,7 +71,7 @@ pub async fn run_background_review_for_episode(
         );
     };
 
-    match run_restricted_review_tool_loop(paths, provider.as_ref(), &snapshot).await {
+    match run_restricted_review_tool_loop(paths, provider.as_ref(), &snapshot, config).await {
         Ok(loop_outcome) if loop_outcome.stopped && all_tool_actions_succeeded(&loop_outcome) => {
             provider_pool.report(provider_idx, CallResult::Success);
             let learning_feedback = summarize_learning_feedback(&loop_outcome.actions);
@@ -103,7 +104,7 @@ pub async fn run_background_review_for_episode(
                 "Restricted ghost review tool loop exceeded max rounds"
             };
             record_failed_review_run(
-                &ledger,
+                ledger,
                 episode_id,
                 error,
                 None,
@@ -125,7 +126,7 @@ pub async fn run_background_review_for_episode(
             );
             provider_pool.report(provider_idx, ProviderPool::classify_error(&err.to_string()));
             metrics.record_review_failed();
-            record_failed_review_run(&ledger, episode_id, &err.to_string(), None, None)
+            record_failed_review_run(ledger, episode_id, &err.to_string(), None, None)
         }
     }
 }
@@ -134,9 +135,29 @@ pub fn spawn_background_review_for_episode(
     paths: Paths,
     provider_pool: Arc<ProviderPool>,
     episode_id: String,
+    config: Config,
 ) {
     tokio::spawn(async move {
-        match run_background_review_for_episode(&paths, provider_pool, &episode_id).await {
+        let ledger = match GhostLedger::open(&paths.ghost_ledger_db()) {
+            Ok(l) => l,
+            Err(err) => {
+                warn!(
+                    episode_id = %episode_id,
+                    error = %err,
+                    "Failed to open GhostLedger for background review"
+                );
+                return;
+            }
+        };
+        match run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &config,
+            &ledger,
+        )
+        .await
+        {
             Ok(outcome) => {
                 info!(
                     episode_id = %episode_id,
@@ -160,6 +181,7 @@ pub async fn run_pending_background_reviews(
     paths: &Paths,
     provider_pool: Arc<ProviderPool>,
     limit: usize,
+    config: &Config,
 ) -> Result<Vec<GhostBackgroundReviewOutcome>> {
     if limit == 0 {
         return Ok(Vec::new());
@@ -170,8 +192,14 @@ pub async fn run_pending_background_reviews(
     let mut outcomes = Vec::with_capacity(episodes.len());
     for episode in episodes {
         outcomes.push(
-            run_background_review_for_episode(paths, Arc::clone(&provider_pool), &episode.id)
-                .await?,
+            run_background_review_for_episode(
+                paths,
+                Arc::clone(&provider_pool),
+                &episode.id,
+                config,
+                &ledger,
+            )
+            .await?,
         );
     }
     Ok(outcomes)
@@ -181,13 +209,14 @@ pub fn spawn_pending_background_reviews(
     paths: Paths,
     provider_pool: Arc<ProviderPool>,
     limit: usize,
+    config: Config,
 ) {
     if limit == 0 {
         return;
     }
 
     tokio::spawn(async move {
-        match run_pending_background_reviews(&paths, provider_pool, limit).await {
+        match run_pending_background_reviews(&paths, provider_pool, limit, &config).await {
             Ok(outcomes) if !outcomes.is_empty() => {
                 info!(
                     reviewed_count = outcomes.len(),
@@ -209,6 +238,7 @@ async fn run_restricted_review_tool_loop(
     paths: &Paths,
     provider: &dyn blockcell_providers::Provider,
     snapshot: &GhostEpisodeSnapshot,
+    config: &Config,
 ) -> Result<GhostReviewToolLoopOutcome> {
     let registry = restricted_review_tool_registry();
     let tools = registry.get_filtered_schemas(REVIEW_ALLOWED_TOOLS);
@@ -247,7 +277,7 @@ async fn run_restricted_review_tool_loop(
             let result = registry
                 .execute(
                     &call.name,
-                    review_tool_context(paths, snapshot)?,
+                    review_tool_context(paths, snapshot, config)?,
                     call.arguments.clone(),
                 )
                 .await;
@@ -346,7 +376,11 @@ fn build_restricted_review_messages(snapshot: &GhostEpisodeSnapshot) -> Vec<Chat
     ]
 }
 
-fn review_tool_context(paths: &Paths, snapshot: &GhostEpisodeSnapshot) -> Result<ToolContext> {
+fn review_tool_context(
+    paths: &Paths,
+    snapshot: &GhostEpisodeSnapshot,
+    config: &Config,
+) -> Result<ToolContext> {
     Ok(ToolContext {
         workspace: paths.workspace(),
         builtin_skills_dir: Some(paths.builtin_skills_dir()),
@@ -356,7 +390,7 @@ fn review_tool_context(paths: &Paths, snapshot: &GhostEpisodeSnapshot) -> Result
         account_id: None,
         sender_id: None,
         chat_id: "ghost_background_review".to_string(),
-        config: Config::default(),
+        config: config.clone(),
         permissions: PermissionSet::new(),
         task_manager: None,
         memory_store: None,
@@ -469,11 +503,9 @@ fn search_score(chunk: &str, tokens: &[String]) -> usize {
 }
 
 fn truncate_chars(text: &str, max_chars: usize) -> String {
-    let truncated = text.chars().take(max_chars).collect::<String>();
-    if text.chars().count() > max_chars {
-        format!("{truncated}...")
-    } else {
-        truncated
+    match text.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}...", &text[..idx]),
+        None => text.to_string(),
     }
 }
 
@@ -869,9 +901,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("run background review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("run background review");
 
         assert_eq!(outcome.status, "completed");
         let mut first_seen = provider.seen_tools.lock().unwrap()[0].clone();
@@ -918,9 +956,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("run background review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("run background review");
 
         assert_eq!(outcome.status, "completed");
         assert_eq!(provider.review_calls.load(Ordering::SeqCst), 1);
@@ -945,9 +989,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("run background review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("run background review");
 
         assert_eq!(outcome.status, "completed");
         let durable_memory = std::fs::read_to_string(paths.memory_md()).expect("read MEMORY.md");
@@ -977,9 +1027,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("record failed review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("record failed review");
 
         assert_eq!(outcome.status, "failed");
         assert_eq!(provider.review_calls.load(Ordering::SeqCst), 1);
@@ -1004,9 +1060,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("record failed review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("record failed review");
 
         assert_eq!(outcome.status, "failed");
         let ledger = GhostLedger::open(&paths.ghost_ledger_db()).expect("open ghost ledger");
@@ -1039,9 +1101,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("record failed review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("record failed review");
 
         assert_eq!(outcome.status, "failed");
         assert!(!paths.user_md().exists());
@@ -1066,9 +1134,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("record failed review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("record failed review");
 
         assert_eq!(outcome.status, "failed");
         assert_eq!(provider.review_calls.load(Ordering::SeqCst), 8);
@@ -1098,9 +1172,15 @@ mod tests {
         let provider_pool =
             ProviderPool::from_single_provider("test/mock", "test", provider.clone());
 
-        let outcome = run_background_review_for_episode(&paths, provider_pool, &episode_id)
-            .await
-            .expect("run background review");
+        let outcome = run_background_review_for_episode(
+            &paths,
+            provider_pool,
+            &episode_id,
+            &Config::default(),
+            &GhostLedger::open(&paths.ghost_ledger_db()).expect("open ledger"),
+        )
+        .await
+        .expect("run background review");
 
         assert_eq!(outcome.status, "completed");
         assert_eq!(provider.review_calls.load(Ordering::SeqCst), 8);

--- a/crates/agent/src/ghost_metrics.rs
+++ b/crates/agent/src/ghost_metrics.rs
@@ -48,11 +48,14 @@ impl GhostMetrics {
         }
     }
 
+    /// Reset all counters. Uses SeqCst ordering to establish a synchronization
+    /// point, ensuring concurrent snapshot() calls see either fully-reset or
+    /// fully-not-reset state (not partial reset).
     pub fn reset(&self) {
-        self.episodes_captured.store(0, Ordering::Relaxed);
-        self.reviews_started.store(0, Ordering::Relaxed);
-        self.reviews_failed.store(0, Ordering::Relaxed);
-        self.dead_letters.store(0, Ordering::Relaxed);
+        self.episodes_captured.store(0, Ordering::SeqCst);
+        self.reviews_started.store(0, Ordering::SeqCst);
+        self.reviews_failed.store(0, Ordering::SeqCst);
+        self.dead_letters.store(0, Ordering::SeqCst);
     }
 }
 

--- a/crates/agent/src/ghost_recall.rs
+++ b/crates/agent/src/ghost_recall.rs
@@ -81,11 +81,9 @@ pub(crate) fn build_memory_context_block(
 }
 
 fn truncate_chars(text: &str, max_chars: usize) -> String {
-    let truncated = text.chars().take(max_chars).collect::<String>();
-    if text.chars().count() > max_chars {
-        format!("{truncated}...")
-    } else {
-        truncated
+    match text.char_indices().nth(max_chars) {
+        Some((idx, _)) => format!("{}...", &text[..idx]),
+        None => text.to_string(),
     }
 }
 

--- a/crates/agent/src/learning_coordinator.rs
+++ b/crates/agent/src/learning_coordinator.rs
@@ -159,11 +159,16 @@ impl LearningCoordinator {
         }
 
         // Check memory nudge (based on user turns)
+        // NOTE: check_memory_nudge() resets the counter internally on trigger,
+        // so we must capture the count BEFORE calling it to report the correct value.
         let mut engine = self.nudge_engine.lock().unwrap_or_else(recover_mutex);
+        let turns_before = engine.turns_since_memory();
         let memory_nudge = engine.check_memory_nudge();
         let memory_due = memory_nudge != NudgeResult::NoNudge && has_memory_store;
 
         // Check skill nudge (based on tool iterations)
+        // Same: capture count before check resets it
+        let iterations_before = engine.iterations_since_skill();
         let skill_nudge = engine.check_skill_nudge();
         let skill_due = skill_nudge != NudgeResult::NoNudge && has_skill_tool;
 
@@ -182,49 +187,35 @@ impl LearningCoordinator {
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         }
 
-        // Determine action
+        // Determine action — use pre-captured counts, not NudgeResult.count
+        // (NudgeResult.count is always 0 because check_*_nudge resets the counter on trigger)
         let new_action = if memory_due && skill_due {
-            let memory_count = match memory_nudge {
-                NudgeResult::SoftNudge { count } | NudgeResult::HardNudge { count } => count,
-                _ => 0,
-            };
-            let skill_count = match skill_nudge {
-                NudgeResult::SoftNudge { count } | NudgeResult::HardNudge { count } => count,
-                _ => 0,
-            };
             LearningAction::CombinedReview {
                 memory_trigger: MemoryTrigger::NudgeThreshold {
-                    count: memory_count,
+                    count: turns_before,
                 },
-                skill_trigger: SkillTrigger::NudgeThreshold { count: skill_count },
+                skill_trigger: SkillTrigger::NudgeThreshold {
+                    count: iterations_before,
+                },
             }
         } else if memory_due {
-            let count = match memory_nudge {
-                NudgeResult::SoftNudge { count } | NudgeResult::HardNudge { count } => count,
-                _ => 0,
-            };
             LearningAction::MemoryReview {
-                trigger: MemoryTrigger::NudgeThreshold { count },
+                trigger: MemoryTrigger::NudgeThreshold {
+                    count: turns_before,
+                },
             }
         } else if skill_due {
-            let count = match skill_nudge {
-                NudgeResult::SoftNudge { count } | NudgeResult::HardNudge { count } => count,
-                _ => 0,
-            };
             LearningAction::SkillReview {
-                trigger: SkillTrigger::NudgeThreshold { count },
+                trigger: SkillTrigger::NudgeThreshold {
+                    count: iterations_before,
+                },
             }
         } else {
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         };
 
-        // Reset counters for triggered nudge types
-        if memory_due {
-            engine.reset_memory();
-        }
-        if skill_due {
-            engine.reset_skill();
-        }
+        // Note: counters are already reset by check_memory_nudge()/check_skill_nudge()
+        // when they trigger, so no additional reset needed here.
 
         // If there's an existing action, merge/upgrade
         match (&new_action, existing_action) {
@@ -258,6 +249,8 @@ impl LearningCoordinator {
         }
 
         let mut engine = self.nudge_engine.lock().unwrap_or_else(recover_mutex);
+        // Capture count before check resets it
+        let turns_before = engine.turns_since_memory();
         let memory_nudge = engine.check_memory_nudge();
         let memory_due = memory_nudge != NudgeResult::NoNudge && has_memory_store;
 
@@ -269,13 +262,10 @@ impl LearningCoordinator {
             return None;
         }
 
-        let count = match memory_nudge {
-            NudgeResult::SoftNudge { count } | NudgeResult::HardNudge { count } => count,
-            _ => 0,
-        };
-
-        engine.reset_memory();
-        Some(MemoryTrigger::NudgeThreshold { count })
+        // Use pre-captured count (check_memory_nudge already reset the counter)
+        Some(MemoryTrigger::NudgeThreshold {
+            count: turns_before,
+        })
     }
 
     /// Check skill nudge only (called each iteration)
@@ -292,6 +282,8 @@ impl LearningCoordinator {
         }
 
         let mut engine = self.nudge_engine.lock().unwrap_or_else(recover_mutex);
+        // Capture count before check resets it
+        let iterations_before = engine.iterations_since_skill();
         let skill_nudge = engine.check_skill_nudge();
         let skill_due = skill_nudge != NudgeResult::NoNudge && has_skill_tool;
 
@@ -309,13 +301,10 @@ impl LearningCoordinator {
             return None;
         }
 
-        let count = match skill_nudge {
-            NudgeResult::SoftNudge { count } | NudgeResult::HardNudge { count } => count,
-            _ => 0,
-        };
-
-        engine.reset_skill();
-        Some(SkillTrigger::NudgeThreshold { count })
+        // Use pre-captured count (check_skill_nudge already reset the counter)
+        Some(SkillTrigger::NudgeThreshold {
+            count: iterations_before,
+        })
     }
 
     /// Reset skill counter after a skill write tool is used

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -3189,6 +3189,7 @@ impl AgentRuntime {
                 self.paths.clone(),
                 Arc::clone(&self.provider_pool),
                 8,
+                self.config.clone(),
             );
         }
     }

--- a/crates/agent/src/skill_index.rs
+++ b/crates/agent/src/skill_index.rs
@@ -42,10 +42,19 @@ fn default_version() -> String {
 /// Skill Progressive Index
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillIndex {
-    /// 所有已索引的 Skill
+    /// 所有已索引的 Skill (key: "category/name" or "name" for no-category skills)
     entries: HashMap<String, SkillIndexEntry>,
     /// 已加载完整内容的 Skill (name → content)
     loaded: HashMap<String, String>,
+}
+
+/// Build a composite key for the entries map to avoid name collisions across categories
+fn composite_key(category: &str, name: &str) -> String {
+    if category.is_empty() {
+        name.to_string()
+    } else {
+        format!("{}/{}", category, name)
+    }
 }
 
 impl SkillIndex {
@@ -92,7 +101,7 @@ impl SkillIndex {
                 // 判断: 如果该目录直接包含 SKILL.md, 则它是一个无 category 的 skill
                 if path.join("SKILL.md").exists() {
                     let entry = Self::build_entry(&dir_name, "", &path);
-                    index.entries.insert(dir_name.clone(), entry);
+                    index.entries.insert(composite_key("", &dir_name), entry);
                 } else {
                     // 该目录是一个 category, 遍历其下的 skill 子目录
                     if let Ok(skill_entries) = std::fs::read_dir(&path) {
@@ -117,7 +126,9 @@ impl SkillIndex {
                                 continue;
                             }
                             let entry = Self::build_entry(&skill_dir_name, &dir_name, &skill_path);
-                            index.entries.insert(skill_dir_name.clone(), entry);
+                            index
+                                .entries
+                                .insert(composite_key(&dir_name, &skill_dir_name), entry);
                         }
                     }
                 }
@@ -323,8 +334,11 @@ impl SkillIndex {
             return Some(content.clone());
         }
 
-        // 从索引查找路径
-        let entry = self.entries.get(name)?;
+        // 从索引查找路径 — try exact key first, then search by name suffix
+        let entry = self
+            .entries
+            .get(name)
+            .or_else(|| self.entries.values().find(|e| e.name == name))?;
         let skill_md = entry.path.join("SKILL.md");
 
         if !skill_md.exists() {
@@ -579,10 +593,10 @@ mod tests {
 
         let index = SkillIndex::build_from_dir(&dir);
         assert_eq!(index.entries().len(), 2);
-        assert!(index.entries().contains_key("flask-deploy"));
-        assert!(index.entries().contains_key("hello"));
+        assert!(index.entries().contains_key("devops/flask-deploy"));
+        assert!(index.entries().contains_key("general/hello"));
 
-        let flask = index.entries().get("flask-deploy").unwrap();
+        let flask = index.entries().get("devops/flask-deploy").unwrap();
         assert_eq!(flask.category, "devops");
         assert_eq!(flask.description, "Deploy Flask apps");
         assert_eq!(flask.tools, vec!["exec", "write_file"]);
@@ -816,7 +830,7 @@ mod tests {
         std::fs::write(skill_dir.join("SKILL.md"), "# Versioned Skill").unwrap();
 
         let index = SkillIndex::build_from_dir(&dir);
-        let entry = index.entries().get("versioned-skill").unwrap();
+        let entry = index.entries().get("general/versioned-skill").unwrap();
         assert_eq!(entry.version, "2.1.0");
         assert_eq!(entry.updated_at.as_deref(), Some("2025-01-15T10:30:00Z"));
 

--- a/crates/agent/src/skill_nudge.rs
+++ b/crates/agent/src/skill_nudge.rs
@@ -261,6 +261,16 @@ impl SkillNudgeEngine {
         }
     }
 
+    /// 获取当前 iterations_since_skill 计数 (用于 coordinator 在 check 前捕获值)
+    pub fn iterations_since_skill(&self) -> u32 {
+        self.iterations_since_skill
+    }
+
+    /// 获取当前 turns_since_memory 计数 (用于 coordinator 在 check 前捕获值)
+    pub fn turns_since_memory(&self) -> u32 {
+        self.turns_since_memory
+    }
+
     /// 重置所有计数器
     pub fn reset(&mut self) {
         self.iterations_since_skill = 0;

--- a/crates/storage/src/ghost_ledger.rs
+++ b/crates/storage/src/ghost_ledger.rs
@@ -721,10 +721,21 @@ impl GhostLedger {
     }
 
     fn latest_episode_field(&self, field: &str) -> Result<Option<String>> {
+        // Whitelist allowed field names to prevent SQL injection
+        let column = match field {
+            "status" => "status",
+            "boundary_kind" => "boundary_kind",
+            _ => {
+                return Err(Error::Storage(format!(
+                    "Invalid field name for latest_episode_field: {}",
+                    field
+                )))
+            }
+        };
         let conn = self.lock_conn()?;
         let sql = format!(
             "SELECT {} FROM episodes ORDER BY created_at DESC, id DESC LIMIT 1",
-            field
+            column
         );
         conn.query_row(&sql, [], |row| row.get::<_, String>(0))
             .optional()


### PR DESCRIPTION
  1. [严重] LearningCoordinator 双重重置导致 nudge count 永远为 0 - check_*_nudge() 内部重置计数器后，evaluate_nudge() 又再次重置 - 修复：调用前捕获计数器值，移除多余重置，添加访问器方法

  2. [严重] GhostLedger latest_episode_field SQL 注入面
     - format!() 直接拼接字段名到 SQL
     - 修复：添加字段名白名单验证

  3. [高] Ghost Background Review 使用 Config::default() - shadow_mode=true 静默抑制审查期间的 recall 注入 - 修复：传递实际 Config 到整个调用链

  4. [高] Ghost Background Review 每次调用打开新 SQLite 连接
     - 修复：传递 GhostLedger 引用复用连接

  5. [高] truncate_chars 双重遍历字符串 - 修复：使用 char_indices().nth() 单次遍历

  6. [高] SkillIndex 不同类别同名技能键冲突
     - 修复：使用 category/name 复合键

  7. [高] is_auto_mem_path 阻止在 memory 目录创建新文件 - 修复：memory_dir 存在且无路径遍历时允许创建

  8. [中] GhostMetrics reset() 非原子性
     - 修复：Relaxed → SeqCst 排序