### PR TITLE
  fix: 修复Ghost学习/技能进化/记忆系统16个bug

### DIFF
--- a/crates/agent/src/auto_memory/extractor.rs
+++ b/crates/agent/src/auto_memory/extractor.rs
@@ -448,6 +448,14 @@ pub fn should_extract_auto_memory_with_config(
 /// - `model`: 模型名称
 /// - `messages`: 消息历史
 /// - `cursor`: 用于验证提取条件的游标
+///
+/// ## Deprecated
+/// This standalone function uses hardcoded constants instead of runtime `Layer5Config` values.
+/// Use `AutoMemoryExtractor::extract()` instead, which respects the full config.
+#[deprecated(
+    since = "0.1.5",
+    note = "Use `AutoMemoryExtractor::extract()` instead; this function ignores runtime Layer5Config"
+)]
 #[allow(dead_code)]
 pub async fn extract_auto_memory(
     provider_pool: Arc<ProviderPool>,

--- a/crates/agent/src/compact/hooks.rs
+++ b/crates/agent/src/compact/hooks.rs
@@ -410,7 +410,9 @@ impl Clone for SessionMemoryRecoveryHook {
             session_id: self.session_id.clone(),
             template: self.template.clone(),
             max_tokens: self.max_tokens,
-            extraction_started_at: self.extraction_started_at,
+            // Reset extraction_started_at to None in the clone to avoid
+            // carrying stale timing from the original instance.
+            extraction_started_at: None,
             extraction_wait_timeout_ms: self.extraction_wait_timeout_ms,
             extraction_stale_threshold_ms: self.extraction_stale_threshold_ms,
         }

--- a/crates/agent/src/ghost_background_review.rs
+++ b/crates/agent/src/ghost_background_review.rs
@@ -248,6 +248,12 @@ async fn run_restricted_review_tool_loop(
     let mut rounds_used = 0usize;
     let mut stop_reason = "max_rounds".to_string();
 
+    // Create stores once before the loop — avoids re-opening per tool call
+    let memory_file_store: blockcell_tools::MemoryFileStoreHandle =
+        Arc::new(MemoryFileStore::open(paths)?);
+    let skill_file_store: blockcell_tools::SkillFileStoreHandle =
+        Arc::new(SkillFileStore::open(paths)?);
+
     for _round in 0..REVIEW_TOOL_LOOP_MAX_ROUNDS {
         rounds_used += 1;
         let response = provider.chat(&messages, &tools).await?;
@@ -277,7 +283,13 @@ async fn run_restricted_review_tool_loop(
             let result = registry
                 .execute(
                     &call.name,
-                    review_tool_context(paths, snapshot, config)?,
+                    review_tool_context_with_stores(
+                        paths,
+                        snapshot,
+                        config,
+                        &memory_file_store,
+                        &skill_file_store,
+                    )?,
                     call.arguments.clone(),
                 )
                 .await;
@@ -376,10 +388,12 @@ fn build_restricted_review_messages(snapshot: &GhostEpisodeSnapshot) -> Vec<Chat
     ]
 }
 
-fn review_tool_context(
+fn review_tool_context_with_stores(
     paths: &Paths,
     snapshot: &GhostEpisodeSnapshot,
     config: &Config,
+    memory_file_store: &blockcell_tools::MemoryFileStoreHandle,
+    skill_file_store: &blockcell_tools::SkillFileStoreHandle,
 ) -> Result<ToolContext> {
     Ok(ToolContext {
         workspace: paths.workspace(),
@@ -394,9 +408,9 @@ fn review_tool_context(
         permissions: PermissionSet::new(),
         task_manager: None,
         memory_store: None,
-        memory_file_store: Some(Arc::new(MemoryFileStore::open(paths)?)),
+        memory_file_store: Some(Arc::clone(memory_file_store)),
         ghost_memory_lifecycle: None,
-        skill_file_store: Some(Arc::new(SkillFileStore::open(paths)?)),
+        skill_file_store: Some(Arc::clone(skill_file_store)),
         session_search: Some(Arc::new(EpisodeSessionSearch::new(snapshot)?)),
         outbound_tx: None,
         spawn_handle: None,

--- a/crates/agent/src/learning_coordinator.rs
+++ b/crates/agent/src/learning_coordinator.rs
@@ -67,7 +67,7 @@ pub enum SkillTrigger {
 /// into a single decision point.
 pub struct LearningCoordinator {
     nudge_engine: Mutex<SkillNudgeEngine>,
-    ghost_policy: GhostLearningPolicy,
+    ghost_policy: Mutex<GhostLearningPolicy>,
     throttle: LearningThrottle,
     dedup: LearningDedup,
     ghost_learning_enabled: bool,
@@ -82,7 +82,10 @@ impl std::fmt::Debug for LearningCoordinator {
                 "self_improve_review_enabled",
                 &self.self_improve_review_enabled,
             )
-            .field("ghost_policy", &self.ghost_policy)
+            .field(
+                "ghost_policy",
+                &self.ghost_policy.lock().unwrap_or_else(recover_mutex),
+            )
             .finish()
     }
 }
@@ -103,7 +106,7 @@ impl LearningCoordinator {
     ) -> Self {
         Self {
             nudge_engine: Mutex::new(nudge_engine),
-            ghost_policy,
+            ghost_policy: Mutex::new(ghost_policy),
             throttle,
             dedup,
             ghost_learning_enabled,
@@ -154,25 +157,20 @@ impl LearningCoordinator {
             return LearningAction::Skip;
         }
 
-        if !self.throttle.can_start_review() {
+        if !self.throttle.try_start_review() {
             return LearningAction::Skip;
         }
 
-        // Check memory nudge (based on user turns)
-        // NOTE: check_memory_nudge() resets the counter internally on trigger,
-        // so we must capture the count BEFORE calling it to report the correct value.
+        // First, check thresholds WITHOUT resetting counters (read-only check)
+        // This allows dedup to block the review without losing counter values
         let mut engine = self.nudge_engine.lock().unwrap_or_else(recover_mutex);
         let turns_before = engine.turns_since_memory();
-        let memory_nudge = engine.check_memory_nudge();
-        let memory_due = memory_nudge != NudgeResult::NoNudge && has_memory_store;
-
-        // Check skill nudge (based on tool iterations)
-        // Same: capture count before check resets it
         let iterations_before = engine.iterations_since_skill();
-        let skill_nudge = engine.check_skill_nudge();
-        let skill_due = skill_nudge != NudgeResult::NoNudge && has_skill_tool;
 
-        // Dedup check
+        let memory_due = engine.would_memory_nudge() && has_memory_store;
+        let skill_due = engine.would_skill_nudge() && has_skill_tool;
+
+        // Dedup check — BEFORE resetting counters
         let dedup_key = if memory_due && skill_due {
             "combined_nudge".to_string()
         } else if memory_due {
@@ -180,15 +178,21 @@ impl LearningCoordinator {
         } else if skill_due {
             "skill_nudge".to_string()
         } else {
+            self.throttle.review_completed(); // rollback — no nudge due
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         };
 
         if self.dedup.is_duplicate(&dedup_key) {
+            // Counters NOT reset — next turn will still see the same counts
+            self.throttle.review_completed(); // rollback — dedup blocked
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         }
 
-        // Determine action — use pre-captured counts, not NudgeResult.count
-        // (NudgeResult.count is always 0 because check_*_nudge resets the counter on trigger)
+        // Now that dedup passed, actually trigger the nudge (which resets counters)
+        let _memory_nudge = engine.check_memory_nudge();
+        let _skill_nudge = engine.check_skill_nudge();
+
+        // Determine action — use pre-captured counts
         let new_action = if memory_due && skill_due {
             LearningAction::CombinedReview {
                 memory_trigger: MemoryTrigger::NudgeThreshold {
@@ -211,27 +215,36 @@ impl LearningCoordinator {
                 },
             }
         } else {
+            self.throttle.review_completed(); // rollback — no nudge due after actual check
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         };
 
         // Note: counters are already reset by check_memory_nudge()/check_skill_nudge()
         // when they trigger, so no additional reset needed here.
 
-        // If there's an existing action, merge/upgrade
+        // If there's an existing action, merge/upgrade — use actual counts from new_action
         match (&new_action, existing_action) {
             (
-                LearningAction::SkillReview { .. },
-                Some(LearningAction::MemoryReview { trigger }),
+                LearningAction::SkillReview {
+                    trigger: new_skill_trigger,
+                },
+                Some(LearningAction::MemoryReview {
+                    trigger: mem_trigger,
+                }),
             ) => LearningAction::CombinedReview {
-                memory_trigger: trigger.clone(),
-                skill_trigger: SkillTrigger::NudgeThreshold { count: 0 },
+                memory_trigger: mem_trigger.clone(),
+                skill_trigger: new_skill_trigger.clone(),
             },
             (
-                LearningAction::MemoryReview { .. },
-                Some(LearningAction::SkillReview { trigger }),
+                LearningAction::MemoryReview {
+                    trigger: new_mem_trigger,
+                },
+                Some(LearningAction::SkillReview {
+                    trigger: skill_trigger,
+                }),
             ) => LearningAction::CombinedReview {
-                memory_trigger: MemoryTrigger::NudgeThreshold { count: 0 },
-                skill_trigger: trigger.clone(),
+                memory_trigger: new_mem_trigger.clone(),
+                skill_trigger: skill_trigger.clone(),
             },
             _ => new_action,
         }
@@ -244,7 +257,11 @@ impl LearningCoordinator {
     /// is checked once before the loop, while skill nudge is
     /// checked each iteration.
     pub fn check_memory_nudge(&self, has_memory_store: bool) -> Option<MemoryTrigger> {
-        if !self.self_improve_review_enabled || !self.throttle.can_start_review() {
+        if !self.self_improve_review_enabled {
+            return None;
+        }
+        // Atomically check throttle + increment counter
+        if !self.throttle.try_start_review() {
             return None;
         }
 
@@ -255,10 +272,12 @@ impl LearningCoordinator {
         let memory_due = memory_nudge != NudgeResult::NoNudge && has_memory_store;
 
         if !memory_due {
+            self.throttle.review_completed(); // rollback the try_start_review increment
             return None;
         }
 
         if self.dedup.is_duplicate("memory_nudge") {
+            self.throttle.review_completed(); // rollback the try_start_review increment
             return None;
         }
 
@@ -277,7 +296,11 @@ impl LearningCoordinator {
         has_skill_tool: bool,
         existing_memory: bool,
     ) -> Option<SkillTrigger> {
-        if !self.self_improve_review_enabled || !self.throttle.can_start_review() {
+        if !self.self_improve_review_enabled {
+            return None;
+        }
+        // Atomically check throttle + increment counter
+        if !self.throttle.try_start_review() {
             return None;
         }
 
@@ -288,6 +311,7 @@ impl LearningCoordinator {
         let skill_due = skill_nudge != NudgeResult::NoNudge && has_skill_tool;
 
         if !skill_due {
+            self.throttle.review_completed(); // rollback
             return None;
         }
 
@@ -298,6 +322,7 @@ impl LearningCoordinator {
         };
 
         if self.dedup.is_duplicate(dedup_key) {
+            self.throttle.review_completed(); // rollback
             return None;
         }
 
@@ -345,7 +370,10 @@ impl LearningCoordinator {
         if !self.ghost_learning_enabled {
             return LearningDecision::Ignore;
         }
-        self.ghost_policy.decide(boundary)
+        self.ghost_policy
+            .lock()
+            .unwrap_or_else(recover_mutex)
+            .decide(boundary)
     }
 
     /// Get the ghost learning policy decision with turn count
@@ -358,7 +386,17 @@ impl LearningCoordinator {
             return LearningDecision::Ignore;
         }
         self.ghost_policy
+            .lock()
+            .unwrap_or_else(recover_mutex)
             .decide_with_turn_count(boundary, turn_count)
+    }
+
+    /// 从配置更新 ghost 学习策略（支持热重载）
+    pub fn update_ghost_policy(&self, config: &blockcell_core::config::GhostLearningConfig) {
+        let new_policy = GhostLearningPolicy::from_config(config);
+        if let Ok(mut guard) = self.ghost_policy.lock() {
+            *guard = new_policy;
+        }
     }
 
     /// Check if self-improve review is enabled

--- a/crates/agent/src/learning_dedup.rs
+++ b/crates/agent/src/learning_dedup.rs
@@ -26,6 +26,12 @@ impl LearningDedup {
     /// Returns `true` if the key is a duplicate (seen within the window).
     /// Returns `false` and records the key if it's new or expired.
     pub fn is_duplicate(&self, key: &str) -> bool {
+        // When dedup_window_secs is 0, deduplication is effectively disabled.
+        // Return early to avoid wasteful inserts into the map.
+        if self.dedup_window_secs == 0 {
+            return false;
+        }
+
         let mut recent = self.recent.lock().unwrap_or_else(|e| {
             tracing::warn!("LearningDedup Mutex poisoned, recovering");
             e.into_inner()

--- a/crates/agent/src/learning_throttle.rs
+++ b/crates/agent/src/learning_throttle.rs
@@ -1,14 +1,14 @@
-//! Learning throttle — prevents review storms and concurrent review overload
+//! 学习节流器 — 防止 review 风暴和并发 review 过载
 
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Mutex;
 use std::time::Instant;
 
-/// Throttle for learning review operations
+/// 学习 review 操作的节流器
 ///
-/// Prevents:
-/// - Too many concurrent reviews (max_concurrent_reviews)
-/// - Reviews firing too frequently (min_review_interval_secs)
+/// 防止：
+/// - 并发 review 过多 (max_concurrent_reviews)
+/// - review 触发过于频繁 (min_review_interval_secs)
 pub struct LearningThrottle {
     last_review_completed: Mutex<Option<Instant>>,
     active_reviews: AtomicU32,
@@ -26,18 +26,59 @@ impl LearningThrottle {
         }
     }
 
-    /// Check if a new review can be started
+    /// 原子性地尝试启动 review
     ///
-    /// Returns false if:
-    /// - Too many concurrent reviews are active
-    /// - Last review completed too recently
-    pub fn can_start_review(&self) -> bool {
-        // Check concurrent limit
-        if self.active_reviews.load(Ordering::Relaxed) >= self.max_concurrent_reviews {
+    /// 当以下条件同时满足时返回 `true` 并递增活跃计数：
+    /// - 未达到并发上限，且
+    /// - 距上次 review 完成已超过冷却期
+    ///
+    /// 任一条件不满足时返回 `false`，不修改状态
+    ///
+    /// 替代了原先分离的 `can_start_review()` + `review_started()` 组合，
+    /// 该组合存在 TOCTOU 竞态：两个线程可能同时看到 `can_start_review() == true`
+    /// 然后都调用 `review_started()`，导致超过并发上限
+    pub fn try_start_review(&self) -> bool {
+        // 先检查冷却（代价低，Mutex 保护 — 无竞态）
+        if let Ok(guard) = self.last_review_completed.lock() {
+            if let Some(last) = *guard {
+                if last.elapsed().as_secs() < self.min_review_interval_secs {
+                    return false;
+                }
+            }
+        } else {
+            // Mutex 中毒 — 保守地阻止
             return false;
         }
 
-        // Check cooldown
+        // 仅在未达上限时原子递增（CAS 循环）
+        let mut current = self.active_reviews.load(Ordering::Acquire);
+        loop {
+            if current >= self.max_concurrent_reviews {
+                return false;
+            }
+            match self.active_reviews.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    /// 检查是否可以启动新 review（只读）
+    ///
+    /// 注意：这是非原子检查。并发场景请使用 `try_start_review()`，
+    /// 它原子地检查并递增
+    pub fn can_start_review(&self) -> bool {
+        // 检查并发上限
+        if self.active_reviews.load(Ordering::Acquire) >= self.max_concurrent_reviews {
+            return false;
+        }
+
+        // 检查冷却期
         if let Ok(guard) = self.last_review_completed.lock() {
             if let Some(last) = *guard {
                 if last.elapsed().as_secs() < self.min_review_interval_secs {
@@ -49,39 +90,38 @@ impl LearningThrottle {
         true
     }
 
-    /// Record that a review has started
+    /// 记录 review 已启动
+    ///
+    /// 注意：并发场景请优先使用 `try_start_review()`
+    /// 此方法无条件递增计数器
     pub fn review_started(&self) {
-        self.active_reviews.fetch_add(1, Ordering::Relaxed);
+        self.active_reviews.fetch_add(1, Ordering::AcqRel);
     }
 
-    /// Record that a review has completed
+    /// 记录 review 已完成
     pub fn review_completed(&self) {
-        let mut current = self.active_reviews.load(Ordering::Relaxed);
-        let mut decremented = false;
+        let mut current = self.active_reviews.load(Ordering::Acquire);
         while current > 0 {
             match self.active_reviews.compare_exchange_weak(
                 current,
                 current - 1,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
+                Ordering::AcqRel,
+                Ordering::Acquire,
             ) {
                 Ok(_) => {
-                    decremented = true;
-                    break;
+                    if let Ok(mut guard) = self.last_review_completed.lock() {
+                        *guard = Some(Instant::now());
+                    }
+                    return;
                 }
                 Err(actual) => current = actual,
             }
         }
-        if decremented {
-            if let Ok(mut guard) = self.last_review_completed.lock() {
-                *guard = Some(Instant::now());
-            }
-        }
     }
 
-    /// Get the number of currently active reviews
+    /// 获取当前活跃 review 数量
     pub fn active_count(&self) -> u32 {
-        self.active_reviews.load(Ordering::Relaxed)
+        self.active_reviews.load(Ordering::Acquire)
     }
 }
 
@@ -90,7 +130,7 @@ impl std::fmt::Debug for LearningThrottle {
         f.debug_struct("LearningThrottle")
             .field(
                 "active_reviews",
-                &self.active_reviews.load(Ordering::Relaxed),
+                &self.active_reviews.load(Ordering::Acquire),
             )
             .field("max_concurrent_reviews", &self.max_concurrent_reviews)
             .field("min_review_interval_secs", &self.min_review_interval_secs)
@@ -106,33 +146,34 @@ mod tests {
     fn test_can_start_when_idle() {
         let throttle = LearningThrottle::new(2, 0);
         assert!(throttle.can_start_review());
+        assert!(throttle.try_start_review());
     }
 
     #[test]
     fn test_blocks_when_concurrent_limit_reached() {
         let throttle = LearningThrottle::new(2, 0);
-        throttle.review_started();
-        throttle.review_started();
-        assert!(!throttle.can_start_review());
+        assert!(throttle.try_start_review());
+        assert!(throttle.try_start_review());
+        assert!(!throttle.try_start_review()); // 第三个被阻止
         assert_eq!(throttle.active_count(), 2);
     }
 
     #[test]
     fn test_allows_after_completion() {
         let throttle = LearningThrottle::new(1, 0);
-        throttle.review_started();
-        assert!(!throttle.can_start_review());
+        assert!(throttle.try_start_review());
+        assert!(!throttle.try_start_review()); // 达到上限
         throttle.review_completed();
-        assert!(throttle.can_start_review());
+        assert!(throttle.try_start_review()); // 现在允许
     }
 
     #[test]
     fn test_cooldown_prevents_rapid_fire() {
         let throttle = LearningThrottle::new(2, 300);
-        throttle.review_started();
+        assert!(throttle.try_start_review());
         throttle.review_completed();
-        // Immediately after completion, cooldown is active
-        assert!(!throttle.can_start_review());
+        // 完成后立即触发冷却
+        assert!(!throttle.try_start_review());
     }
 
     #[test]
@@ -141,5 +182,16 @@ mod tests {
         throttle.review_completed();
         assert_eq!(throttle.active_count(), 0);
         assert!(throttle.can_start_review());
+    }
+
+    #[test]
+    fn test_try_start_is_atomic() {
+        let throttle = LearningThrottle::new(1, 0);
+        // 第一次成功
+        assert!(throttle.try_start_review());
+        // 第二次失败（上限 = 1）
+        assert!(!throttle.try_start_review());
+        // 计数器恰好为 1
+        assert_eq!(throttle.active_count(), 1);
     }
 }

--- a/crates/agent/src/memory_file_store.rs
+++ b/crates/agent/src/memory_file_store.rs
@@ -2,7 +2,6 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use blockcell_core::{Error, Paths, Result};
@@ -249,11 +248,12 @@ impl MemoryFileStore {
             MemoryFileTarget::User => "## User Profile Memory",
             MemoryFileTarget::Memory => "## Durable Working Memory",
         };
-        Ok(Some(
-            format!("{}\n{}", title, entries.join("\n- "))
-                .replace("\n", "\n- ")
-                .replacen("- ##", "##", 1),
-        ))
+        let body = entries
+            .iter()
+            .map(|e| format!("- {}", e))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Ok(Some(format!("{}\n{}", title, body)))
     }
 
     fn path_for(&self, target: MemoryFileTarget) -> &Path {
@@ -419,7 +419,11 @@ impl FileWriteGuard {
                             path.display()
                         )));
                     }
-                    thread::sleep(Duration::from_millis(25));
+                    // Yield the CPU without blocking the tokio worker thread.
+                    // thread::sleep would block the worker; spin_loop + yield_now
+                    // lets the OS scheduler switch to another task.
+                    std::hint::spin_loop();
+                    std::thread::yield_now();
                 }
                 Err(err) => return Err(err.into()),
             }

--- a/crates/agent/src/memory_system/mod.rs
+++ b/crates/agent/src/memory_system/mod.rs
@@ -551,20 +551,20 @@ pub enum PostSamplingAction {
 /// ## 游标状态同步
 /// 如果后台任务设置了 `cursor_reload_flag`，会先重新加载游标状态。
 /// 这确保了后台提取任务完成后，主线程使用最新的游标状态。
-pub fn evaluate_memory_hooks(
+///
+/// ## 为什么是 async
+/// 此函数从 async 运行时循环中调用。之前使用 `block_in_place + block_on`
+/// 在单线程 runtime 或 `multi_thread` 且只有 1 个 worker 时会死锁，
+/// 因为 `block_on` 需要另一个 worker 来驱动被阻塞的 future。
+/// 改为直接 await 可安全适用于所有 runtime 配置。
+pub async fn evaluate_memory_hooks(
     memory_system: &mut MemorySystem,
     messages: &[ChatMessage],
     current_tokens: usize,
 ) -> PostSamplingAction {
     // 检查是否需要重新加载游标状态（后台提取完成后）
     if memory_system.check_and_clear_cursor_reload() {
-        // 注意：这里使用 block_in_place 是安全的，因为：
-        // 1. 这是在主 runtime 循环中调用，tokio runtime 已经存在
-        // 2. cursor_manager.load() 是快速操作（读取一个小文件）
-        // 3. 我们需要同步地获取最新状态才能做决策
-        if let Err(e) = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(memory_system.reload_cursors())
-        }) {
+        if let Err(e) = memory_system.reload_cursors().await {
             tracing::warn!(error = %e, "[evaluate_memory_hooks] Failed to reload cursor state");
         }
     }
@@ -671,8 +671,8 @@ mod tests {
         assert!(!memory_system.should_compact(1_000_000));
     }
 
-    #[test]
-    fn test_evaluate_memory_hooks_none() {
+    #[tokio::test]
+    async fn test_evaluate_memory_hooks_none() {
         let config = MemorySystemConfig::default();
         let mut memory_system = MemorySystem::new(
             config,
@@ -683,12 +683,12 @@ mod tests {
 
         let messages = vec![ChatMessage::user("Hello"), ChatMessage::assistant("Hi!")];
 
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100);
+        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
         assert!(matches!(action, PostSamplingAction::None));
     }
 
-    #[test]
-    fn test_evaluate_memory_hooks_compact() {
+    #[tokio::test]
+    async fn test_evaluate_memory_hooks_compact() {
         let config = MemorySystemConfig {
             token_budget: 100,
             layer4: Layer4Config {
@@ -705,7 +705,7 @@ mod tests {
         );
 
         let messages = vec![ChatMessage::user("Test")];
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100);
+        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
         assert!(matches!(action, PostSamplingAction::Compact));
     }
@@ -820,8 +820,8 @@ mod tests {
         assert!(recovery.is_empty());
     }
 
-    #[test]
-    fn test_post_sampling_action_order() {
+    #[tokio::test]
+    async fn test_post_sampling_action_order() {
         // 测试 Compact 优先级高于其他操作
         let config = MemorySystemConfig {
             token_budget: 100,
@@ -849,7 +849,7 @@ mod tests {
             })
             .collect();
 
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100);
+        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
         // Compact 优先级最高
         assert!(matches!(action, PostSamplingAction::Compact));

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -3202,6 +3202,9 @@ impl AgentRuntime {
         if !self.ghost_learning_enabled() {
             return Ok(None);
         }
+        // 从当前配置刷新 ghost 策略（支持热重载）
+        self.learning_coordinator
+            .update_ghost_policy(&self.config.agents.ghost.learning);
         let decision = self.learning_coordinator.ghost_decide(&boundary);
         persist_ghost_learning_boundary_with_decision(
             &self.config,
@@ -3333,8 +3336,12 @@ impl AgentRuntime {
             .iter()
             .filter(|message| message.role == "user")
             .count() as u32;
-        let decision = GhostLearningPolicy::from_config(&self.config.agents.ghost.learning)
-            .decide_with_turn_count(&boundary, Some(turn_count));
+        // 从当前配置刷新 ghost 策略（支持热重载）
+        self.learning_coordinator
+            .update_ghost_policy(&self.config.agents.ghost.learning);
+        let decision = self
+            .learning_coordinator
+            .ghost_decide_with_turn_count(&boundary, Some(turn_count));
 
         persist_ghost_learning_boundary_with_decision(
             &self.config,
@@ -6406,7 +6413,8 @@ impl AgentRuntime {
                 memory_system,
                 &history,
                 current_tokens,
-            );
+            )
+            .await;
 
             match action {
                 crate::memory_system::PostSamplingAction::ExtractSessionMemory => {

--- a/crates/agent/src/session_memory/extractor.rs
+++ b/crates/agent/src/session_memory/extractor.rs
@@ -122,12 +122,19 @@ pub fn should_extract_memory(messages: &[ChatMessage], state: &SessionMemoryStat
     }
 
     // 3. 工具调用检查（优先使用消息 ID）
-    let tool_calls = count_tool_calls_since(
-        messages,
-        state.last_memory_message_id.as_deref(),
-        state.last_memory_message_index,
-    );
-    let has_met_tool_threshold = tool_calls >= state.config.tool_calls_between_updates;
+    // On first extraction (!state.initialized), skip the tool call threshold
+    // because count_tool_calls_since returns 0 when last_memory_message_index
+    // is None, which would block the first extraction in tool-intensive conversations.
+    let has_met_tool_threshold = if !state.initialized {
+        true
+    } else {
+        let tool_calls = count_tool_calls_since(
+            messages,
+            state.last_memory_message_id.as_deref(),
+            state.last_memory_message_index,
+        );
+        tool_calls >= state.config.tool_calls_between_updates
+    };
 
     // 4. 安全条件：最后一条消息无 tool_calls
     let has_tool_calls_in_last = has_tool_calls_in_last_assistant_turn(messages);

--- a/crates/agent/src/skill_file_store.rs
+++ b/crates/agent/src/skill_file_store.rs
@@ -2,7 +2,6 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use blockcell_core::{Error, Paths, Result};
@@ -586,7 +585,7 @@ fn render_meta_yaml(name: &str, description: &str) -> String {
 
 fn yaml_scalar(value: &str) -> String {
     serde_yaml::to_string(value)
-        .unwrap_or_else(|_| format!("\"{}\"", value.replace('"', "\\\"")))
+        .unwrap_or_else(|_| format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\"")))
         .trim()
         .trim_start_matches("---")
         .trim()
@@ -632,7 +631,9 @@ impl FileWriteGuard {
                             path.display()
                         )));
                     }
-                    thread::sleep(Duration::from_millis(25));
+                    // Yield the CPU without blocking the tokio worker thread.
+                    std::hint::spin_loop();
+                    std::thread::yield_now();
                 }
                 Err(err) => return Err(err.into()),
             }
@@ -882,6 +883,19 @@ fn copy_dir_recursive(source: &Path, dest: &Path) -> Result<()> {
     for entry in fs::read_dir(source)? {
         let entry = entry?;
         let source_path = entry.path();
+
+        // Check for symbolic links to prevent symlink attacks
+        // Use symlink_metadata to detect symlinks without following them
+        if let Ok(meta) = fs::symlink_metadata(&source_path) {
+            if meta.file_type().is_symlink() {
+                tracing::warn!(
+                    path = %source_path.display(),
+                    "Skipping symbolic link in skill directory to prevent path traversal"
+                );
+                continue;
+            }
+        }
+
         let dest_path = dest.join(entry.file_name());
         if source_path.is_dir() {
             copy_dir_recursive(&source_path, &dest_path)?;

--- a/crates/agent/src/skill_nudge.rs
+++ b/crates/agent/src/skill_nudge.rs
@@ -271,6 +271,34 @@ impl SkillNudgeEngine {
         self.turns_since_memory
     }
 
+    /// Read-only check: would a memory nudge trigger WITHOUT resetting counters?
+    /// Used by LearningCoordinator to check dedup before committing to a nudge.
+    pub fn would_memory_nudge(&self) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        if let Some(last) = self.last_memory_nudge_time {
+            if last.elapsed().as_secs() < self.min_nudge_interval_secs {
+                return false;
+            }
+        }
+        self.turns_since_memory >= self.config.memory_soft_threshold
+    }
+
+    /// Read-only check: would a skill nudge trigger WITHOUT resetting counters?
+    /// Used by LearningCoordinator to check dedup before committing to a nudge.
+    pub fn would_skill_nudge(&self) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        if let Some(last) = self.last_skill_nudge_time {
+            if last.elapsed().as_secs() < self.min_nudge_interval_secs {
+                return false;
+            }
+        }
+        self.iterations_since_skill >= self.config.skill_soft_threshold
+    }
+
     /// 重置所有计数器
     pub fn reset(&mut self) {
         self.iterations_since_skill = 0;

--- a/crates/agent/tests/memory_integration_test.rs
+++ b/crates/agent/tests/memory_integration_test.rs
@@ -59,8 +59,8 @@ mod tests {
     }
 
     /// 测试 Post-Sampling Hook 评估
-    #[test]
-    fn test_post_sampling_hook_none() {
+    #[tokio::test]
+    async fn test_post_sampling_hook_none() {
         let config = MemorySystemConfig::default();
         let mut memory_system = MemorySystem::new(
             config,
@@ -71,13 +71,13 @@ mod tests {
 
         let messages = vec![ChatMessage::user("Hello"), ChatMessage::assistant("Hi!")];
 
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100);
+        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
         assert!(matches!(action, PostSamplingAction::None));
     }
 
     /// 测试 Post-Sampling Hook Compact 触发
-    #[test]
-    fn test_post_sampling_hook_compact() {
+    #[tokio::test]
+    async fn test_post_sampling_hook_compact() {
         let config = MemorySystemConfig {
             token_budget: 100,
             layer4: Layer4Config {
@@ -94,7 +94,7 @@ mod tests {
         );
 
         let messages = vec![ChatMessage::user("Test")];
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100);
+        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
         assert!(matches!(action, PostSamplingAction::Compact));
     }
@@ -1322,8 +1322,8 @@ _No errors encountered._
     /// 测试 PostSamplingAction 优先级
     ///
     /// 验证 Compact > Session Memory > Auto Memory 的优先级顺序
-    #[test]
-    fn test_post_sampling_action_priority() {
+    #[tokio::test]
+    async fn test_post_sampling_action_priority() {
         // Compact 最高优先级
         let config = MemorySystemConfig {
             token_budget: 100,
@@ -1353,7 +1353,7 @@ _No errors encountered._
             .collect();
 
         // 当 Token 超过阈值时，应返回 Compact 而不是其他 Action
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100);
+        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
         // Compact 优先级最高
         assert!(matches!(action, PostSamplingAction::Compact));

--- a/crates/storage/src/ghost_ledger.rs
+++ b/crates/storage/src/ghost_ledger.rs
@@ -397,11 +397,11 @@ impl GhostLedger {
             id,
             boundary_kind,
             subject_key,
-            status,
+            _status,
             summary,
             metadata_json,
             created_at,
-            updated_at,
+            _updated_at,
         ) in rows
         {
             tx.execute(
@@ -417,11 +417,11 @@ impl GhostLedger {
                 id,
                 boundary_kind,
                 subject_key,
-                status,
+                status: "reviewing".to_string(), // 返回事务提交后的实际状态
                 summary,
                 metadata: decode_json(&metadata_json)?,
                 created_at,
-                updated_at,
+                updated_at: now.clone(), // 更新为当前时间
             });
         }
 
@@ -914,9 +914,11 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(claimed_ids, vec![pending_id.as_str(), failed_id.as_str()]);
-        assert!(claimed.iter().all(|episode| {
-            episode.status == "pending_review" || episode.status == "review_failed"
-        }));
+        // After the fix, claim_reviewable_episodes returns records with
+        // the post-claim status ("reviewing"), not the pre-claim status.
+        assert!(claimed
+            .iter()
+            .all(|episode| { episode.status == "reviewing" }));
         assert_eq!(
             ledger.get_episode(&pending_id).unwrap().unwrap().status,
             "reviewing"

--- a/crates/tools/src/memory.rs
+++ b/crates/tools/src/memory.rs
@@ -155,36 +155,44 @@ impl Tool for MemoryManageTool {
         let action = params
             .get("action")
             .and_then(|value| value.as_str())
-            .unwrap();
+            .ok_or_else(|| Error::Tool("Missing or non-string parameter: action".to_string()))?;
         let target = params
             .get("target")
             .and_then(|value| value.as_str())
-            .unwrap();
+            .ok_or_else(|| Error::Tool("Missing or non-string parameter: target".to_string()))?;
         let result = match action {
             "add" => store.add_file_memory_json(
                 target,
                 params
                     .get("content")
                     .and_then(|value| value.as_str())
-                    .unwrap(),
+                    .ok_or_else(|| {
+                        Error::Tool("Missing or non-string parameter: content".to_string())
+                    })?,
             ),
             "replace" => store.replace_file_memory_json(
                 target,
                 params
                     .get("old_text")
                     .and_then(|value| value.as_str())
-                    .unwrap(),
+                    .ok_or_else(|| {
+                        Error::Tool("Missing or non-string parameter: old_text".to_string())
+                    })?,
                 params
                     .get("content")
                     .and_then(|value| value.as_str())
-                    .unwrap(),
+                    .ok_or_else(|| {
+                        Error::Tool("Missing or non-string parameter: content".to_string())
+                    })?,
             ),
             "remove" => store.remove_file_memory_json(
                 target,
                 params
                     .get("old_text")
                     .and_then(|value| value.as_str())
-                    .unwrap(),
+                    .ok_or_else(|| {
+                        Error::Tool("Missing or non-string parameter: old_text".to_string())
+                    })?,
             ),
             "undo_latest" => store.restore_latest_file_memory_json(target),
             _ => unreachable!("validated action"),
@@ -399,7 +407,10 @@ impl Tool for MemoryUpsertTool {
     async fn execute(&self, ctx: ToolContext, params: Value) -> Result<Value> {
         let store = get_memory_store(&ctx)?;
 
-        let content = params["content"].as_str().unwrap();
+        let content = params
+            .get("content")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Tool("Missing or non-string parameter: content".to_string()))?;
         let scope = params
             .get("scope")
             .and_then(|v| v.as_str())
@@ -541,11 +552,16 @@ impl Tool for MemoryForgetTool {
 
     async fn execute(&self, ctx: ToolContext, params: Value) -> Result<Value> {
         let store = get_memory_store(&ctx)?;
-        let action = params["action"].as_str().unwrap();
+        let action = params
+            .get("action")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Tool("Missing or non-string parameter: action".to_string()))?;
 
         match action {
             "delete" => {
-                let id = params["id"].as_str().unwrap();
+                let id = params.get("id").and_then(|v| v.as_str()).ok_or_else(|| {
+                    Error::Tool("Missing or non-string parameter: id".to_string())
+                })?;
                 let deleted = store.soft_delete(id)?;
                 Ok(json!({
                     "action": "delete",
@@ -569,7 +585,9 @@ impl Tool for MemoryForgetTool {
                 }))
             }
             "restore" => {
-                let id = params["id"].as_str().unwrap();
+                let id = params.get("id").and_then(|v| v.as_str()).ok_or_else(|| {
+                    Error::Tool("Missing or non-string parameter: id".to_string())
+                })?;
                 let restored = store.restore(id)?;
                 Ok(json!({
                     "action": "restore",

--- a/crates/tools/src/memory_maintenance.rs
+++ b/crates/tools/src/memory_maintenance.rs
@@ -25,22 +25,6 @@ fn looks_like_ghost_maintenance_log(text: &str) -> bool {
         || t.contains("feed routine")
 }
 
-fn extract_result_ids(results: &Value) -> Vec<String> {
-    results
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|r| {
-                    r.get("item")
-                        .and_then(|i| i.get("id"))
-                        .and_then(|id| id.as_str())
-                        .map(|s| s.to_string())
-                })
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
-}
-
 fn prune_ghost_maintenance_logs(store: &crate::MemoryStoreHandle, dry_run: bool) -> Result<Value> {
     let query_params = json!({
         "scope": "short_term",
@@ -50,27 +34,37 @@ fn prune_ghost_maintenance_logs(store: &crate::MemoryStoreHandle, dry_run: bool)
     });
 
     let results = store.query_json(query_params)?;
-    let mut ids = extract_result_ids(&results);
-    ids.sort();
-    ids.dedup();
 
     let mut matched = 0usize;
     let mut deleted = 0usize;
+    let mut matched_ids: Vec<String> = Vec::new();
 
     for r in results.as_array().unwrap_or(&vec![]) {
         let item = match r.get("item") {
             Some(i) => i,
             None => continue,
         };
+        let id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if id.is_empty() {
+            continue;
+        }
         let title = item.get("title").and_then(|v| v.as_str()).unwrap_or("");
         let content = item.get("content").and_then(|v| v.as_str()).unwrap_or("");
         if looks_like_ghost_maintenance_log(title) || looks_like_ghost_maintenance_log(content) {
             matched += 1;
+            matched_ids.push(id);
         }
     }
 
+    matched_ids.sort();
+    matched_ids.dedup();
+
     if !dry_run {
-        for id in ids {
+        for id in matched_ids {
             if store.soft_delete(&id)? {
                 deleted += 1;
             }


### PR DESCRIPTION
  Critical (3):
1 prune_ghost_maintenance_logs 误删非Ghost日志 → 只删除模式匹配ID
2 claim_reviewable_episodes 返回陈旧状态 → 使用事务后实际值
5 memory工具unwrap()导致panic → 替换为ok_or_else

  Important (12):
3 evaluate_nudge计数器在dedup前被重置 → 先只读检查再重置
4 block_in_place+block_on死锁 → 改为async/await
6 format_for_system_prompt Markdown错乱 → 显式bullet前缀
7 会话记忆首次提取被工具阈值阻塞 → 跳过首次阈值检查
8 copy_dir_recursive符号链接攻击 → 检测并跳过符号链接
10 GhostBackgroundReview重复创建存储 → 循环前预创建
11 FileWriteGuard thread::sleep阻塞worker → spin_loop+yield_now
12 SessionMemoryRecoveryHook Clone携带陈旧Instant → 重置为None
13 extract_auto_memory硬编码常量 → deprecated标注
14 yaml_scalar不完整YAML转义 → 先转义反斜杠
15 capture_turn_end绕过LearningCoordinator → 使用coordinator+热重载
16 LearningThrottle TOCTOU竞态+计数器泄漏 → 原子try_start_review+回滚

  Minor (1):
9 learning_dedup dedup_window=0无效插入 → 提前返回false