### PR TITLE
  feat: 添加 DeepSeek V4 thinking mode 支持，更新默认模型与上下文配置

### DIFF
--- a/bin/blockcell/src/commands/config_cmd.rs
+++ b/bin/blockcell/src/commands/config_cmd.rs
@@ -47,7 +47,7 @@ pub async fn schema() -> anyhow::Result<()> {
                             "provider": { "type": "string", "description": "Explicit provider name override" },
                             "evolutionModel": { "type": "string", "description": "Model for self-evolution pipeline" },
                             "evolutionProvider": { "type": "string", "description": "Provider for self-evolution pipeline" },
-                            "maxContextTokens": { "type": "integer", "default": 32000 },
+                            "maxContextTokens": { "type": "integer", "default": 1048576 },
                             "allowedMcpServers": { "type": "array", "items": { "type": "string" }, "description": "MCP server allowlist for this agent" },
                             "allowedMcpTools": { "type": "array", "items": { "type": "string" }, "description": "MCP tool allowlist for this agent" }
                         }

--- a/bin/blockcell/src/commands/gateway/config_api.rs
+++ b/bin/blockcell/src/commands/gateway/config_api.rs
@@ -181,6 +181,8 @@ pub(super) async fn handle_config_test_provider(
         None,
         &[],
         blockcell_core::config::ToolCallMode::Native,
+        "",
+        None,
     );
 
     match provider.chat(&test_messages, &[]).await {

--- a/bin/blockcell/src/commands/onboard.rs
+++ b/bin/blockcell/src/commands/onboard.rs
@@ -117,10 +117,12 @@ const EXAMPLE_CONFIG: &str = r#"{
       "maxTokens": 8192,
       "temperature": 0.7,
       "maxToolIterations": 20,
+      "maxContextTokens": 1048576,
+      "reasoningEffort": "high",
       "modelPool": [
         {
           "provider": "deepseek",
-          "model": "deepseek-chat",
+          "model": "deepseek-v4-pro",
           "weight": 1,
           "priority": 1
         }

--- a/bin/blockcell/src/commands/setup.rs
+++ b/bin/blockcell/src/commands/setup.rs
@@ -559,7 +559,7 @@ fn normalize_channel(input: &str) -> Option<&'static str> {
 
 fn default_model_for_provider(provider: &str) -> &'static str {
     match provider {
-        "deepseek" => "deepseek-chat",
+        "deepseek" => "deepseek-v4-pro",
         "openai" => "gpt-4o",
         "anthropic" => "claude-sonnet-4-20250514",
         "kimi" => "moonshot-v1-8k",
@@ -674,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_default_model() {
-        assert_eq!(default_model_for_provider("deepseek"), "deepseek-chat");
+        assert_eq!(default_model_for_provider("deepseek"), "deepseek-v4-pro");
         assert_eq!(default_model_for_provider("openai"), "gpt-4o");
         assert_eq!(default_model_for_provider("kimi"), "moonshot-v1-8k");
         assert_eq!(default_model_for_provider("zhipu"), "glm-4");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -78,7 +78,7 @@ pub enum ToolCallMode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct ModelEntry {
-    /// 模型名称，例如 "deepseek-chat"、"claude-3-5-sonnet"
+    /// 模型名称，例如 "deepseek-v4-pro"、"claude-3-5-sonnet"
     pub model: String,
     /// 对应 providers 表中的 key，例如 "deepseek"、"anthropic"
     pub provider: String,
@@ -163,6 +163,13 @@ pub struct AgentDefaults {
     /// Allowed MCP tool names visible to this agent.
     #[serde(default)]
     pub allowed_mcp_tools: Vec<String>,
+    /// 推理强度控制（DeepSeek V4 thinking mode 等）：
+    /// - "off": 禁用思考 (thinking.type = disabled)
+    /// - "low"/"medium"/"high": reasoning_effort = high (DeepSeek 默认)
+    /// - "max": reasoning_effort = max (最深推理)
+    /// - None: 不发送任何参数，由 provider 自行决定
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 fn default_workspace() -> String {
@@ -170,7 +177,7 @@ fn default_workspace() -> String {
 }
 
 fn default_model() -> String {
-    "".to_string()
+    "deepseek-v4-pro".to_string()
 }
 
 fn default_max_tokens() -> u32 {
@@ -194,7 +201,7 @@ fn default_llm_retry_delay_ms() -> u64 {
 }
 
 fn default_max_context_tokens() -> u32 {
-    32000
+    1_048_576 // 1M 上下文，适配 DeepSeek V4 Pro 等 1M 上下文模型
 }
 
 fn default_true() -> bool {
@@ -219,6 +226,7 @@ impl Default for AgentDefaults {
             model_pool: Vec::new(),
             allowed_mcp_servers: Vec::new(),
             allowed_mcp_tools: Vec::new(),
+            reasoning_effort: None,
         }
     }
 }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -306,3 +306,46 @@ impl ToolCallAccumulator {
         }
     }
 }
+
+/// DeepSeek thinking mode 要求：所有包含 tool_calls 的 assistant 消息
+/// 必须携带 `reasoning_content` 字段回传 API，否则会触发 400 错误。
+/// 此函数检查并修复缺失的 reasoning_content。
+///
+/// 仅在 thinking mode 开启且模型为 DeepSeek thinking 模型时生效。
+pub fn sanitize_thinking_mode_messages(
+    messages: &mut Vec<ChatMessage>,
+    model: &str,
+    reasoning_effort: Option<&str>,
+) {
+    // 如果 thinking mode 未开启，不做任何处理
+    if reasoning_effort.is_none() || reasoning_effort == Some("off") {
+        return;
+    }
+    // 如果模型不是 DeepSeek thinking 模型，跳过
+    if !is_thinking_model(model) {
+        return;
+    }
+    // 对于有 tool_calls 但没有 reasoning_content 的 assistant 消息，
+    // 注入空 reasoning_content 占位符以避免 400 错误
+    for msg in messages.iter_mut() {
+        if msg.role == "assistant" {
+            if msg
+                .tool_calls
+                .as_ref()
+                .is_some_and(|tc| !tc.is_empty())
+            {
+                if msg.reasoning_content.is_none() {
+                    msg.reasoning_content = Some(String::new());
+                }
+            }
+        }
+    }
+}
+
+/// 判断模型是否为 DeepSeek thinking 模型（需要 reasoning_content 回传）。
+pub fn is_thinking_model(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    lower.contains("deepseek-v4")
+        || lower.contains("deepseek-reasoner")
+        || lower.contains("deepseek-r1")
+}

--- a/crates/providers/src/factory.rs
+++ b/crates/providers/src/factory.rs
@@ -101,6 +101,7 @@ pub fn create_provider_with_tool_mode(
 ) -> anyhow::Result<Box<dyn Provider>> {
     let max_tokens = config.agents.defaults.max_tokens;
     let temperature = temperature_override.unwrap_or(config.agents.defaults.temperature);
+    let reasoning_effort = config.agents.defaults.reasoning_effort.as_deref();
 
     // 优先级1：显式指定
     // 优先级2：model 前缀推断
@@ -258,6 +259,8 @@ pub fn create_provider_with_tool_mode(
                         global_proxy,
                         no_proxy,
                         tool_call_mode.unwrap_or(ToolCallMode::Native),
+                        effective_provider,
+                        reasoning_effort,
                     )) as Box<dyn Provider>)
                 }
             }

--- a/crates/providers/src/openai.rs
+++ b/crates/providers/src/openai.rs
@@ -7,7 +7,7 @@ use blockcell_core::{Error, Result};
 use futures::StreamExt;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::time::Duration;
@@ -37,6 +37,12 @@ pub struct OpenAIProvider {
     max_tokens: u32,
     temperature: f32,
     tool_call_mode: AtomicU8,
+    /// Provider 名称（如 "deepseek"、"openrouter"、"nvidia-nim" 等），
+    /// 用于判断 reasoning_effort 参数的注入方式。
+    provider_name: String,
+    /// 推理强度配置（如 "off"、"high"、"max"），
+    /// None 表示不注入任何 thinking/reasoning_effort 参数。
+    reasoning_effort: Option<String>,
 }
 
 struct TextToolMarkupStreamFilter {
@@ -192,6 +198,8 @@ impl OpenAIProvider {
             None,
             &[],
             ToolCallMode::Native,
+            "",
+            None,
         )
     }
 
@@ -206,6 +214,8 @@ impl OpenAIProvider {
         global_proxy: Option<&str>,
         no_proxy: &[String],
         tool_call_mode: ToolCallMode,
+        provider_name: &str,
+        reasoning_effort: Option<&str>,
     ) -> Self {
         let resolved_base = api_base
             .unwrap_or("https://api.openai.com/v1")
@@ -226,6 +236,8 @@ impl OpenAIProvider {
             max_tokens,
             temperature,
             tool_call_mode: AtomicU8::new(Self::mode_to_u8(tool_call_mode)),
+            provider_name: provider_name.to_string(),
+            reasoning_effort: reasoning_effort.map(|s| s.to_string()),
         }
     }
 
@@ -1102,6 +1114,57 @@ impl OpenAIProvider {
         result
     }
 
+    /// 根据 reasoning_effort 配置和 provider 名称，向请求 body 注入
+    /// thinking / reasoning_effort / chat_template_kwargs 参数。
+    ///
+    /// 仅对已知支持 thinking/reasoning 的 provider 注入参数：
+    /// - DeepSeek 原生及 OpenRouter/Novita/Fireworks/SGLang 等中继使用
+    ///   顶层 `thinking` 和 `reasoning_effort` 字段
+    /// - NVIDIA NIM 使用 `chat_template_kwargs` 包装
+    /// - 其他 provider（OpenAI、Groq、Kimi、Zhipu 等）不支持，不注入
+    pub fn apply_reasoning_effort(
+        body: &mut Value,
+        effort: Option<&str>,
+        provider_name: &str,
+    ) {
+        let Some(effort) = effort else { return };
+        // 仅对支持 thinking/reasoning 的 provider 生效
+        if !supports_thinking_mode(provider_name) {
+            return;
+        }
+        let normalized = effort.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "off" | "disabled" | "none" | "false" => {
+                if is_nvidia_nim(provider_name) {
+                    body["chat_template_kwargs"] = json!({"thinking": false});
+                } else {
+                    body["thinking"] = json!({"type": "disabled"});
+                }
+            }
+            "low" | "minimal" | "medium" | "mid" | "high" | "" => {
+                if is_nvidia_nim(provider_name) {
+                    body["chat_template_kwargs"] =
+                        json!({"thinking": true, "reasoning_effort": "high"});
+                } else {
+                    body["reasoning_effort"] = json!("high");
+                    body["thinking"] = json!({"type": "enabled"});
+                }
+            }
+            "xhigh" | "max" | "highest" => {
+                if is_nvidia_nim(provider_name) {
+                    body["chat_template_kwargs"] =
+                        json!({"thinking": true, "reasoning_effort": "max"});
+                } else {
+                    body["reasoning_effort"] = json!("max");
+                    body["thinking"] = json!({"type": "enabled"});
+                }
+            }
+            _ => {
+                // 未知值不修改，由 provider 自行决定
+            }
+        }
+    }
+
     /// Send a chat request to the API.
     async fn send_request(
         &self,
@@ -1145,7 +1208,15 @@ impl OpenAIProvider {
         };
         info!(url = %url, model = %self.model, tools_count = tools.len(), messages_count = messages.len(), mode = %mode, "Calling LLM");
 
-        let request_body = serde_json::to_string(&request)
+        // 序列化为 Value 以便注入 reasoning_effort/thinking/chat_template_kwargs
+        let mut body: Value = serde_json::to_value(&request)
+            .map_err(|e| Error::Provider(format!("Failed to serialize request: {}", e)))?;
+        Self::apply_reasoning_effort(
+            &mut body,
+            self.reasoning_effort.as_deref(),
+            &self.provider_name,
+        );
+        let request_body = serde_json::to_string(&body)
             .map_err(|e| Error::Provider(format!("Failed to serialize request: {}", e)))?;
         debug!(body_len = request_body.len(), "Request body prepared");
         debug!(target: "chat::request", request_body, "Request detail");
@@ -1338,6 +1409,15 @@ struct StreamRequest {
     max_tokens: u32,
     temperature: f32,
     stream: bool,
+    /// 流式请求中包含 token 用量统计（DeepSeek V4 等）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream_options: Option<StreamOptions>,
+}
+
+/// 流式请求选项：让服务端在最后一个 chunk 中返回 usage 统计。
+#[derive(Debug, Serialize)]
+struct StreamOptions {
+    include_usage: bool,
 }
 
 #[async_trait]
@@ -1512,17 +1592,29 @@ impl Provider for OpenAIProvider {
             max_tokens: self.max_tokens,
             temperature: self.temperature,
             stream: true,
+            stream_options: Some(StreamOptions {
+                include_usage: true,
+            }),
         };
 
+        // 序列化为 Value 以便注入 reasoning_effort/thinking/chat_template_kwargs
+        let mut body: Value = serde_json::to_value(&request)
+            .map_err(|e| Error::Provider(format!("Failed to serialize stream request: {}", e)))?;
+        Self::apply_reasoning_effort(
+            &mut body,
+            self.reasoning_effort.as_deref(),
+            &self.provider_name,
+        );
+
         info!(url = %url, model = %self.model, "Starting streaming LLM call");
-        debug!(target: "chat::request", request = serde_json::to_string(&request).unwrap_or_default(), "Request detail");
+        debug!(target: "chat::request", request = serde_json::to_string(&body).unwrap_or_default(), "Request detail");
 
         let response = self
             .client
             .post(&url)
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
-            .json(&request)
+            .json(&body)
             .send()
             .await
             .map_err(|e| Error::Provider(format!("Stream request failed: {}", e)))?;
@@ -1697,6 +1789,101 @@ impl Provider for OpenAIProvider {
 mod tests {
     use super::*;
     use blockcell_core::types::ChatMessage;
+
+    #[test]
+    fn test_apply_reasoning_effort_deepseek_max() {
+        let mut body = json!({"model": "deepseek-v4-pro", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, Some("max"), "deepseek");
+        assert_eq!(body["reasoning_effort"].as_str(), Some("max"));
+        assert_eq!(
+            body.pointer("/thinking/type").and_then(Value::as_str),
+            Some("enabled")
+        );
+    }
+
+    #[test]
+    fn test_apply_reasoning_effort_deepseek_off() {
+        let mut body = json!({"model": "deepseek-v4-pro", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, Some("off"), "deepseek");
+        assert_eq!(
+            body.pointer("/thinking/type").and_then(Value::as_str),
+            Some("disabled")
+        );
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_effort_nvidia_nim_max() {
+        let mut body = json!({"model": "deepseek-v4-pro", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, Some("max"), "nvidia-nim");
+        assert_eq!(
+            body.pointer("/chat_template_kwargs/thinking")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            body.pointer("/chat_template_kwargs/reasoning_effort")
+                .and_then(Value::as_str),
+            Some("max")
+        );
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_effort_nvidia_nim_off() {
+        let mut body = json!({"model": "deepseek-v4-pro", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, Some("off"), "nvidia-nim");
+        assert_eq!(
+            body.pointer("/chat_template_kwargs/thinking")
+                .and_then(Value::as_bool),
+            Some(false)
+        );
+        assert!(body
+            .pointer("/chat_template_kwargs/reasoning_effort")
+            .is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_effort_none_does_nothing() {
+        let mut body = json!({"model": "deepseek-v4-pro", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, None, "deepseek");
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_effort_unsupported_provider_not_affected() {
+        // OpenAI、Groq、Kimi 等不支持 thinking 模式，不应注入任何参数
+        let mut body = json!({"model": "gpt-4o", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, Some("high"), "openai");
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+        assert!(body.get("chat_template_kwargs").is_none());
+
+        let mut body2 = json!({"model": "moonshot-v1", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body2, Some("max"), "kimi");
+        assert!(body2.get("thinking").is_none());
+        assert!(body2.get("reasoning_effort").is_none());
+
+        let mut body3 = json!({"model": "llama3", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body3, Some("high"), "groq");
+        assert!(body3.get("thinking").is_none());
+        assert!(body3.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn test_apply_reasoning_effort_openrouter_supported() {
+        // OpenRouter 作为 DeepSeek 中继，应支持 thinking 模式
+        let mut body = json!({"model": "deepseek-v4-pro", "messages": []});
+        OpenAIProvider::apply_reasoning_effort(&mut body, Some("high"), "openrouter");
+        assert_eq!(body["reasoning_effort"].as_str(), Some("high"));
+        assert_eq!(
+            body.pointer("/thinking/type").and_then(Value::as_str),
+            Some("enabled")
+        );
+    }
 
     #[test]
     fn test_parse_xml_tool_call() {
@@ -2049,4 +2236,24 @@ ls -la
         assert_eq!(sanitized[2].role, "tool");
         assert_eq!(sanitized[2].tool_call_id.as_deref(), Some("call-1"));
     }
+}
+
+/// 判断 provider 是否为 NVIDIA NIM 类型。
+/// NVIDIA NIM 使用 `chat_template_kwargs` 而非顶层 `thinking`/`reasoning_effort`。
+fn is_nvidia_nim(provider_name: &str) -> bool {
+    let lower = provider_name.to_ascii_lowercase();
+    lower.contains("nvidia") || lower.contains("nim")
+}
+
+/// 判断 provider 是否支持 thinking/reasoning 模式参数。
+/// 仅 DeepSeek 系列及其中继（OpenRouter/Novita/Fireworks/SGLang）和 NVIDIA NIM 支持。
+/// OpenAI、Groq、Kimi、Zhipu 等不支持，注入这些参数会导致 API 报错。
+fn supports_thinking_mode(provider_name: &str) -> bool {
+    let lower = provider_name.to_ascii_lowercase();
+    lower.contains("deepseek")
+        || lower.contains("openrouter")
+        || lower.contains("novita")
+        || lower.contains("fireworks")
+        || lower.contains("sglang")
+        || is_nvidia_nim(provider_name)
 }


### PR DESCRIPTION
  核心变更

  1. crates/providers/src/openai.rs — 核心：reasoning_effort/thinking 参数注入
    - 新增 provider_name 和 reasoning_effort 字段到 OpenAIProvider
    - 新增 apply_reasoning_effort() 函数：根据 provider 类型注入 thinking/reasoning_effort/chat_template_kwargs 参数
    - 新增 supports_thinking_mode() 守卫：仅对 DeepSeek/OpenRouter/Novita/Fireworks/SGLang/NVIDIA NIM 注入，避免 OpenAI/Groq/Kimi/Zhipu 等不支持的 provider 报错
    - 新增 StreamOptions 结构体，流式请求支持 stream_options: { include_usage: true }
    - send_request() 和 chat_stream() 改为先序列化为 Value 再注入参数
    - 新增 7 个单元测试覆盖各分支
  2. crates/core/src/config.rs — 配置层
    - AgentDefaults 新增 reasoning_effort: Option<String> 字段
    - default_model() 从 "" 改为 "deepseek-v4-pro"
    - default_max_context_tokens() 从 32000 改为 1_048_576（1M 上下文）
  3. crates/core/src/types.rs — thinking mode sanitizer
    - 新增 sanitize_thinking_mode_messages()：修复 DeepSeek thinking mode 下 assistant 消息缺失 reasoning_content 导致的 400 错误
    - 新增 is_thinking_model() 辅助函数
  4. crates/providers/src/factory.rs — 传递 reasoning_effort 和 provider_name 到 OpenAIProvider
  5. bin/blockcell/src/commands/onboard.rs — EXAMPLE_CONFIG 更新
    - 默认模型 deepseek-chat → deepseek-v4-pro
    - 新增 "reasoningEffort": "high" 和 "maxContextTokens": 1048576
  6. bin/blockcell/src/commands/setup.rs — DeepSeek 默认模型更新为 deepseek-v4-pro
  7. bin/blockcell/src/commands/config_cmd.rs — JSON Schema 中 maxContextTokens 默认值更新为 1048576
  8. bin/blockcell/src/commands/gateway/config_api.rs — 适配 OpenAIProvider::new_with_proxy() 新参数