### PR TITLE
  fix: 修复Ghost学习/技能进化节流系统6个并发bug

### DIFF
--- a/crates/agent/src/ghost_background_review.rs
+++ b/crates/agent/src/ghost_background_review.rs
@@ -191,16 +191,24 @@ pub async fn run_pending_background_reviews(
     let episodes = ledger.claim_reviewable_episodes(limit)?;
     let mut outcomes = Vec::with_capacity(episodes.len());
     for episode in episodes {
-        outcomes.push(
-            run_background_review_for_episode(
-                paths,
-                Arc::clone(&provider_pool),
-                &episode.id,
-                config,
-                &ledger,
-            )
-            .await?,
-        );
+        match run_background_review_for_episode(
+            paths,
+            Arc::clone(&provider_pool),
+            &episode.id,
+            config,
+            &ledger,
+        )
+        .await
+        {
+            Ok(outcome) => outcomes.push(outcome),
+            Err(err) => {
+                tracing::warn!(
+                    episode_id = %episode.id,
+                    error = %err,
+                    "Background review for episode failed, continuing with remaining episodes"
+                );
+            }
+        }
     }
     Ok(outcomes)
 }

--- a/crates/agent/src/learning_coordinator.rs
+++ b/crates/agent/src/learning_coordinator.rs
@@ -178,13 +178,13 @@ impl LearningCoordinator {
         } else if skill_due {
             "skill_nudge".to_string()
         } else {
-            self.throttle.review_completed(); // rollback — no nudge due
+            self.throttle.rollback_review(); // rollback — no nudge due
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         };
 
         if self.dedup.is_duplicate(&dedup_key) {
             // Counters NOT reset — next turn will still see the same counts
-            self.throttle.review_completed(); // rollback — dedup blocked
+            self.throttle.rollback_review(); // rollback — dedup blocked
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         }
 
@@ -215,7 +215,7 @@ impl LearningCoordinator {
                 },
             }
         } else {
-            self.throttle.review_completed(); // rollback — no nudge due after actual check
+            self.throttle.rollback_review(); // rollback — no nudge due after actual check
             return existing_action.cloned().unwrap_or(LearningAction::Skip);
         };
 
@@ -272,12 +272,12 @@ impl LearningCoordinator {
         let memory_due = memory_nudge != NudgeResult::NoNudge && has_memory_store;
 
         if !memory_due {
-            self.throttle.review_completed(); // rollback the try_start_review increment
+            self.throttle.rollback_review(); // rollback the try_start_review increment
             return None;
         }
 
         if self.dedup.is_duplicate("memory_nudge") {
-            self.throttle.review_completed(); // rollback the try_start_review increment
+            self.throttle.rollback_review(); // rollback the try_start_review increment
             return None;
         }
 
@@ -299,9 +299,18 @@ impl LearningCoordinator {
         if !self.self_improve_review_enabled {
             return None;
         }
-        // Atomically check throttle + increment counter
-        if !self.throttle.try_start_review() {
-            return None;
+        // Only claim a new throttle slot if there's no existing memory review.
+        // If memory review already claimed a slot, skill nudge reuses it
+        // (they'll be combined into a single review). Without this check,
+        // both check_memory_nudge() and check_skill_nudge() would call
+        // try_start_review(), incrementing the throttle counter twice,
+        // but only one review_completed() call would happen on completion,
+        // leaving a phantom active review that blocks future reviews.
+        if !existing_memory {
+            // Atomically check throttle + increment counter
+            if !self.throttle.try_start_review() {
+                return None;
+            }
         }
 
         let mut engine = self.nudge_engine.lock().unwrap_or_else(recover_mutex);
@@ -311,7 +320,9 @@ impl LearningCoordinator {
         let skill_due = skill_nudge != NudgeResult::NoNudge && has_skill_tool;
 
         if !skill_due {
-            self.throttle.review_completed(); // rollback
+            if !existing_memory {
+                self.throttle.rollback_review(); // rollback only if we claimed the slot
+            }
             return None;
         }
 
@@ -322,7 +333,9 @@ impl LearningCoordinator {
         };
 
         if self.dedup.is_duplicate(dedup_key) {
-            self.throttle.review_completed(); // rollback
+            if !existing_memory {
+                self.throttle.rollback_review(); // rollback only if we claimed the slot
+            }
             return None;
         }
 
@@ -394,9 +407,7 @@ impl LearningCoordinator {
     /// 从配置更新 ghost 学习策略（支持热重载）
     pub fn update_ghost_policy(&self, config: &blockcell_core::config::GhostLearningConfig) {
         let new_policy = GhostLearningPolicy::from_config(config);
-        if let Ok(mut guard) = self.ghost_policy.lock() {
-            *guard = new_policy;
-        }
+        *self.ghost_policy.lock().unwrap_or_else(recover_mutex) = new_policy;
     }
 
     /// Check if self-improve review is enabled

--- a/crates/agent/src/learning_throttle.rs
+++ b/crates/agent/src/learning_throttle.rs
@@ -119,6 +119,27 @@ impl LearningThrottle {
         }
     }
 
+    /// 回滚 try_start_review 的递增（未实际启动 review 时调用）
+    ///
+    /// 仅递减计数器，不启动冷却计时器。
+    /// 与 review_completed() 的区别：review_completed 表示一个真实的
+    /// review 已完成，应启动冷却；rollback 表示获取了槽位但未使用，
+    /// 不应影响后续 review 的启动时机。
+    pub fn rollback_review(&self) {
+        let mut current = self.active_reviews.load(Ordering::Acquire);
+        while current > 0 {
+            match self.active_reviews.compare_exchange_weak(
+                current,
+                current - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
     /// 获取当前活跃 review 数量
     pub fn active_count(&self) -> u32 {
         self.active_reviews.load(Ordering::Acquire)

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -6355,7 +6355,11 @@ impl AgentRuntime {
         if !final_response.is_empty() {
             if let Some(mode) = deferred_review_mode.take() {
                 if self.learning_coordinator.is_self_improve_enabled() {
-                    self.learning_coordinator.review_started();
+                    // NOTE: Do NOT call review_started() here.
+                    // check_memory_nudge()/check_skill_nudge() already called
+                    // try_start_review() which incremented the throttle counter.
+                    // Calling review_started() again would double-increment,
+                    // leaving a phantom active review that blocks future reviews.
                     let notify = Some((msg.channel.clone(), msg.chat_id.clone()));
                     self.spawn_review(mode, deferred_review_snapshot, notify);
                 }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -313,7 +313,7 @@ impl ToolCallAccumulator {
 ///
 /// 仅在 thinking mode 开启且模型为 DeepSeek thinking 模型时生效。
 pub fn sanitize_thinking_mode_messages(
-    messages: &mut Vec<ChatMessage>,
+    messages: &mut [ChatMessage],
     model: &str,
     reasoning_effort: Option<&str>,
 ) {
@@ -328,16 +328,11 @@ pub fn sanitize_thinking_mode_messages(
     // 对于有 tool_calls 但没有 reasoning_content 的 assistant 消息，
     // 注入空 reasoning_content 占位符以避免 400 错误
     for msg in messages.iter_mut() {
-        if msg.role == "assistant" {
-            if msg
-                .tool_calls
-                .as_ref()
-                .is_some_and(|tc| !tc.is_empty())
-            {
-                if msg.reasoning_content.is_none() {
-                    msg.reasoning_content = Some(String::new());
-                }
-            }
+        if msg.role == "assistant"
+            && msg.tool_calls.as_ref().is_some_and(|tc| !tc.is_empty())
+            && msg.reasoning_content.is_none()
+        {
+            msg.reasoning_content = Some(String::new());
         }
     }
 }

--- a/crates/providers/src/openai.rs
+++ b/crates/providers/src/openai.rs
@@ -1122,11 +1122,7 @@ impl OpenAIProvider {
     ///   顶层 `thinking` 和 `reasoning_effort` 字段
     /// - NVIDIA NIM 使用 `chat_template_kwargs` 包装
     /// - 其他 provider（OpenAI、Groq、Kimi、Zhipu 等）不支持，不注入
-    pub fn apply_reasoning_effort(
-        body: &mut Value,
-        effort: Option<&str>,
-        provider_name: &str,
-    ) {
+    pub fn apply_reasoning_effort(body: &mut Value, effort: Option<&str>, provider_name: &str) {
         let Some(effort) = effort else { return };
         // 仅对支持 thinking/reasoning 的 provider 生效
         if !supports_thinking_mode(provider_name) {

--- a/crates/storage/src/ghost_ledger.rs
+++ b/crates/storage/src/ghost_ledger.rs
@@ -404,15 +404,27 @@ impl GhostLedger {
             _updated_at,
         ) in rows
         {
-            tx.execute(
-                "
+            let affected = tx
+                .execute(
+                    "
                 UPDATE episodes
                 SET status = 'reviewing', updated_at = ?2
                 WHERE id = ?1 AND status IN ('pending_review', 'review_failed')
                 ",
-                params![id, now],
-            )
-            .map_err(map_sqlite_error)?;
+                    params![id, now],
+                )
+                .map_err(map_sqlite_error)?;
+            // Only add to claimed if the UPDATE actually affected a row.
+            // Without this check, concurrent processes could both SELECT the same
+            // episode but only one UPDATE succeeds — both would incorrectly add it
+            // to their claimed vector.
+            if affected == 0 {
+                tracing::debug!(
+                    episode_id = %id,
+                    "Episode already claimed by another process, skipping"
+                );
+                continue;
+            }
             claimed.push(GhostEpisodeRecord {
                 id,
                 boundary_kind,


### PR DESCRIPTION
  1. ghost_ledger.rs: claim_reviewable_episodes()竞态条件 - 检查UPDATE受影响行数，防止并发进程重复claim同一episode

  2. learning_coordinator.rs: check_skill_nudge()节流计数器双重递增
     - existing_memory=true时复用已有槽位，不再调用try_start_review()

  3. runtime.rs: review_started()节流计数器双重递增 - 移除多余的review_started()调用，try_start_review()已递增

  4. learning_throttle.rs: rollback调用触发冷却计时器
     - 新增rollback_review()方法，仅递减计数器不启动冷却
     - 7处回滚调用从review_completed()改为rollback_review()

  5. ghost_background_review.rs: 首个失败阻塞所有后续episode审查 - 改为match处理结果，失败时warn并继续处理剩余episode

  6. learning_coordinator.rs: update_ghost_policy() mutex中毒时静默丢弃更新
     - 使用unwrap_or_else(recover_mutex)模式，与同struct其他方法一致