### PR TITLE
refactor: extract .env loading into shared env_file module

### DIFF
--- a/bin/blockcell/src/commands/agent.rs
+++ b/bin/blockcell/src/commands/agent.rs
@@ -366,6 +366,7 @@ pub async fn run(
     provider: Option<String>,
 ) -> anyhow::Result<()> {
     let root_paths = Paths::new();
+    super::env_file::ensure_and_load_blockcell_env(&root_paths)?;
     let root_config = Config::load_or_default(&root_paths)?;
     let resolved = resolve_agent_context(
         &root_config,

--- a/bin/blockcell/src/commands/env_file.rs
+++ b/bin/blockcell/src/commands/env_file.rs
@@ -1,0 +1,104 @@
+use anyhow::Context;
+use blockcell_core::Paths;
+use std::fs;
+use std::path::Path;
+use tracing::info;
+
+fn default_env_template() -> &'static str {
+    "BLOCKCELL_API_TOKEN=\nOPENAI_API_KEY=\nANTHROPIC_API_KEY=\nGEMINI_API_KEY=\n"
+}
+
+fn parse_env_assignment(line: &str) -> Option<(String, String)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let body = trimmed.strip_prefix("export ").unwrap_or(trimmed).trim();
+    let (key, value) = body.split_once('=')?;
+    let key = key.trim();
+    if key.is_empty() {
+        return None;
+    }
+
+    let mut value = value.trim().to_string();
+    if value.len() >= 2 {
+        let quoted = (value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\''));
+        if quoted {
+            value = value[1..value.len() - 1].to_string();
+        }
+    }
+
+    Some((key.to_string(), value))
+}
+
+pub fn ensure_and_load_blockcell_env(paths: &Paths) -> anyhow::Result<()> {
+    paths.ensure_dirs().with_context(|| {
+        format!(
+            "failed to create blockcell dirs at {}",
+            paths.base.display()
+        )
+    })?;
+
+    let env_path = paths.env_file();
+    if !env_path.exists() {
+        fs::write(&env_path, default_env_template()).with_context(|| {
+            format!(
+                "failed to create default env file at {}",
+                env_path.display()
+            )
+        })?;
+        info!(path = %env_path.display(), "Created default blockcell .env file");
+    }
+
+    load_env_file(&env_path)
+}
+
+fn load_env_file(path: &Path) -> anyhow::Result<()> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("failed to read env file {}", path.display()))?;
+
+    let mut loaded = 0usize;
+    for line in content.lines() {
+        if let Some((key, value)) = parse_env_assignment(line) {
+            // This runs during command startup, before worker threads are spawned.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            loaded += 1;
+        }
+    }
+
+    info!(path = %path.display(), loaded, "Loaded blockcell .env file");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_env_assignment;
+
+    #[test]
+    fn parse_env_assignment_handles_plain_export_and_quotes() {
+        assert_eq!(
+            parse_env_assignment("GBRAIN_EMBEDDING_MODEL=embedding-3"),
+            Some((
+                "GBRAIN_EMBEDDING_MODEL".to_string(),
+                "embedding-3".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_env_assignment("export GBRAIN_EMBEDDING_DIMENSIONS='2048'"),
+            Some((
+                "GBRAIN_EMBEDDING_DIMENSIONS".to_string(),
+                "2048".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_env_assignment_ignores_comments_and_blank_lines() {
+        assert_eq!(parse_env_assignment("# GBRAIN_EMBEDDING_MODEL=x"), None);
+        assert_eq!(parse_env_assignment("   "), None);
+    }
+}

--- a/bin/blockcell/src/commands/gateway.rs
+++ b/bin/blockcell/src/commands/gateway.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use blockcell_agent::{
     AgentRuntime, CapabilityRegistryAdapter, CheckpointManager, ConfirmRequest,
     CoreEvolutionAdapter, MemoryStoreAdapter, MessageBus, ProviderLLMBridge, ResponseCacheConfig,
@@ -37,8 +36,6 @@ use blockcell_tools::{
     ToolRegistry,
 };
 use std::collections::HashMap;
-use std::fs;
-use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tracing::{debug, error, info, warn};
@@ -1025,78 +1022,9 @@ async fn auth_middleware(
 // Main gateway entry point
 // ---------------------------------------------------------------------------
 
-fn default_env_template() -> &'static str {
-    "BLOCKCELL_API_TOKEN=\nOPENAI_API_KEY=\nANTHROPIC_API_KEY=\nGEMINI_API_KEY=\n"
-}
-
-fn parse_env_assignment(line: &str) -> Option<(String, String)> {
-    let trimmed = line.trim();
-    if trimmed.is_empty() || trimmed.starts_with('#') {
-        return None;
-    }
-
-    let body = trimmed.strip_prefix("export ").unwrap_or(trimmed).trim();
-    let (key, value) = body.split_once('=')?;
-    let key = key.trim();
-    if key.is_empty() {
-        return None;
-    }
-
-    let mut value = value.trim().to_string();
-    if value.len() >= 2 {
-        let quoted = (value.starts_with('"') && value.ends_with('"'))
-            || (value.starts_with('\'') && value.ends_with('\''));
-        if quoted {
-            value = value[1..value.len() - 1].to_string();
-        }
-    }
-
-    Some((key.to_string(), value))
-}
-
-fn ensure_and_load_gateway_env(paths: &Paths) -> anyhow::Result<()> {
-    paths.ensure_dirs().with_context(|| {
-        format!(
-            "failed to create blockcell dirs at {}",
-            paths.base.display()
-        )
-    })?;
-
-    let env_path = paths.env_file();
-    if !env_path.exists() {
-        fs::write(&env_path, default_env_template()).with_context(|| {
-            format!(
-                "failed to create default env file at {}",
-                env_path.display()
-            )
-        })?;
-        info!(path = %env_path.display(), "Created default gateway .env file");
-    }
-
-    load_env_file(&env_path)
-}
-
-fn load_env_file(path: &Path) -> anyhow::Result<()> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("failed to read env file {}", path.display()))?;
-
-    let mut loaded = 0usize;
-    for line in content.lines() {
-        if let Some((key, value)) = parse_env_assignment(line) {
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            loaded += 1;
-        }
-    }
-
-    info!(path = %path.display(), loaded, "Loaded gateway env file");
-    Ok(())
-}
-
 pub async fn run(cli_host: Option<String>, cli_port: Option<u16>) -> anyhow::Result<()> {
     let paths = Paths::new();
-    ensure_and_load_gateway_env(&paths)?;
+    super::env_file::ensure_and_load_blockcell_env(&paths)?;
     let mut config = Config::load_or_default(&paths)?;
 
     // Ensure autoUpgrade.manifestUrl has a value (migrates old configs with empty string)

--- a/bin/blockcell/src/commands/mod.rs
+++ b/bin/blockcell/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod config_cmd;
 pub mod cron;
 pub mod doctor;
 pub mod embedded_skills;
+pub mod env_file;
 pub mod evolve;
 pub mod gateway;
 pub mod knowledge_cmd;

--- a/crates/providers/src/openai_responses.rs
+++ b/crates/providers/src/openai_responses.rs
@@ -464,7 +464,10 @@ struct ResponsesRequest {
     temperature: f32,
 }
 
-fn serialize_temperature<S>(temperature: &f32, serializer: S) -> std::result::Result<S::Ok, S::Error>
+fn serialize_temperature<S>(
+    temperature: &f32,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,
 {


### PR DESCRIPTION
将 gateway.rs 中的 .env 文件解析与加载逻辑提取到独立的 env_file 模块，
使 agent 和 gateway 命令共享同一套环境变量加载流程。agent.rs 现在在启
动时也会加载 blockcell .env 文件，确保两个入口命令行为一致。

变更概要：

- 新增 env_file.rs — 抽取共享的 .env 解析和加载逻辑，含单元测试
- 修改 gateway.rs — 移除已提取的函数，改为调用共享模块
- 修改 agent.rs — 在 run() 启动时新增 ensure_and_load_blockcell_env 调用
- 修改 mod.rs — 注册 env_file 模块