### PR TITLE
fix: 修复记忆系统 6 项并发/原子性缺陷（Session/Auto/Compact/Dream）

### DIFF
--- a/crates/agent/src/auto_memory/cursor.rs
+++ b/crates/agent/src/auto_memory/cursor.rs
@@ -627,6 +627,27 @@ impl ExtractionCursorManager {
     }
 
     /// 重置所有游标
+    /// Compact 后重置消息计数基线
+    ///
+    /// Compact 会把历史替换为短摘要，消息数大幅减少。
+    /// 如果不重置 `last_message_count`，后续 `should_extract_full` 中
+    /// `current_message_count.saturating_sub(self.last_message_count)` 会一直为 0，
+    /// 导致 Auto Memory 长期不再触发。
+    pub fn reset_message_count_baseline(&mut self, post_compact_message_count: usize) {
+        for cursor in self.cursors.values_mut() {
+            // 只在当前基线大于压缩后消息数时才需要重置（说明 compact 发生了）
+            if cursor.last_message_count > post_compact_message_count {
+                tracing::debug!(
+                    memory_type = cursor.memory_type.name(),
+                    old_count = cursor.last_message_count,
+                    new_count = post_compact_message_count,
+                    "[cursor] Compact 后重置消息计数基线"
+                );
+                cursor.last_message_count = post_compact_message_count;
+            }
+        }
+    }
+
     pub fn reset_all(&mut self) {
         self.cursors.clear();
         for mt in MemoryType::all() {

--- a/crates/agent/src/auto_memory/extractor.rs
+++ b/crates/agent/src/auto_memory/extractor.rs
@@ -368,7 +368,6 @@ impl AutoMemoryExtractor {
                             memory_type = memory_type.name(),
                             "[auto_memory] 提取未产生内容变更（正常 no-op）"
                         );
-                        cb.record_success();
                         // 正常推进游标，防止下次继续触发
                         let cursor = {
                             let mut c = self.cursor_manager.get_cursor(memory_type);
@@ -390,6 +389,13 @@ impl AutoMemoryExtractor {
                             }
                             Ok(()) => false,
                         };
+                        // cursor 保存失败时记入熔断器失败，避免存储层故障被掩盖
+                        if cursor_save_failed {
+                            cb.record_failure();
+                            get_memory_metrics().layer5.record_extraction_failure();
+                        } else {
+                            cb.record_success();
+                        }
                         return ExtractionResult {
                             memory_type,
                             success: true, // 无变化视为成功
@@ -449,8 +455,13 @@ impl AutoMemoryExtractor {
                     );
                 }
 
-                // 熔断器记录成功
-                cb.record_success();
+                // 熔断器记录：cursor 保存失败时记入失败，避免存储层故障被掩盖
+                if cursor_save_failed {
+                    cb.record_failure();
+                    get_memory_metrics().layer5.record_extraction_failure();
+                } else {
+                    cb.record_success();
+                }
 
                 ExtractionResult {
                     memory_type,

--- a/crates/agent/src/dream_state.rs
+++ b/crates/agent/src/dream_state.rs
@@ -103,7 +103,10 @@ async fn write_dream_state(base_dir: &Path, state: &DreamStateData) -> std::io::
 /// 确保 Dream 整合的三重门控机制能正确判断会话数量。
 ///
 /// 使用跨进程锁保护 read-modify-write 序列，防止并发会话初始化导致计数丢失。
-pub async fn increment_dream_session_count(base_dir: &Path) {
+///
+/// 返回 `Result`：调用者（runtime）仅在递增成功后才提交 sidecar marker，
+/// 避免递增失败但 marker 已创建导致该 session 永久漏计。
+pub async fn increment_dream_session_count(base_dir: &Path) -> std::io::Result<()> {
     let lock_path = dream_state_lock_path(base_dir);
     let _lock_guard = match CrossProcessLock::acquire(&lock_path) {
         Ok(guard) => guard,
@@ -112,25 +115,21 @@ pub async fn increment_dream_session_count(base_dir: &Path) {
             // Fallback: proceed without lock (best-effort)
             let mut state = read_dream_state(base_dir).await;
             state.current_session_count = state.current_session_count.saturating_add(1);
-            if let Err(e) = write_dream_state(base_dir, &state).await {
-                warn!(error = %e, "[layer6] 保存 .dream_state.json 失败");
-            }
-            return;
+            write_dream_state(base_dir, &state).await?;
+            return Ok(());
         }
     };
 
     let mut state = read_dream_state(base_dir).await;
     state.current_session_count = state.current_session_count.saturating_add(1);
 
-    if let Err(e) = write_dream_state(base_dir, &state).await {
-        warn!(error = %e, "[layer6] 保存 .dream_state.json 失败");
-    } else {
-        info!(
-            current_session_count = state.current_session_count,
-            last_session_count = state.last_session_count,
-            "[layer6] 会话计数已递增并持久化（跨进程锁保护）"
-        );
-    }
+    write_dream_state(base_dir, &state).await?;
+    info!(
+        current_session_count = state.current_session_count,
+        last_session_count = state.last_session_count,
+        "[layer6] 会话计数已递增并持久化（跨进程锁保护）"
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -106,7 +106,7 @@ pub use memory_file_store::{
 };
 pub use memory_system::{
     evaluate_memory_hooks, BackgroundTaskHandle, MemorySystem, MemorySystemConfig,
-    MemorySystemState, PostSamplingAction,
+    MemorySystemState, PostSamplingActions,
 };
 pub use response_cache::{ResponseCache, ResponseCacheConfig};
 pub use runtime::{create_evolution_deploy_callback, AgentRuntime, ConfirmRequest};

--- a/crates/agent/src/memory_system/mod.rs
+++ b/crates/agent/src/memory_system/mod.rs
@@ -32,6 +32,22 @@ pub struct SessionMemoryExtractionResult {
     pub success: bool,
 }
 
+/// Session Memory 状态的持久化版本
+///
+/// 用于在 runtime 重建时恢复提取进度，避免 Gateway/异步消息模式下
+/// `tokens_at_last_extraction` 和 `initialized` 丢失导致重复触发提取。
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct PersistedSessionMemoryState {
+    /// 上次提取时的 Token 数
+    tokens_at_last_extraction: usize,
+    /// 是否已初始化
+    initialized: bool,
+    /// 上次提取时的消息 ID
+    last_memory_message_id: Option<String>,
+    /// 上次提取时的消息索引（向后兼容，用于消息无 ID 时的 fallback）
+    last_memory_message_index: Option<usize>,
+}
+
 /// 记忆系统状态
 #[derive(Debug, Default)]
 pub struct MemorySystemState {
@@ -120,11 +136,352 @@ impl MemorySystem {
         }
     }
 
-    /// 异步初始化（加载游标状态 + 标记会话活跃）
+    /// 异步初始化（加载游标状态 + 标记会话活跃 + 恢复持久化的 Session Memory 状态）
     pub async fn initialize(&mut self) -> std::io::Result<()> {
         self.cursor_manager.load().await?;
+        // 恢复持久化的 Session Memory 状态（避免 runtime 重建后丢失提取进度）
+        self.load_session_memory_state().await?;
         // 标记会话为活跃状态
         self.mark_session_active().await
+    }
+
+    /// 从会话目录加载持久化的 Session Memory 状态
+    ///
+    /// 在 Gateway/异步消息模式下，runtime 会被重建，此方法确保
+    /// `tokens_at_last_extraction`、`initialized` 和 `last_memory_message_id`
+    /// 在 runtime 重建后仍能正确恢复，避免重复触发提取。
+    async fn load_session_memory_state(&mut self) -> std::io::Result<()> {
+        let state_path = self.session_memory_state_path();
+        if !state_path.exists() {
+            return Ok(());
+        }
+
+        match std::fs::read_to_string(&state_path) {
+            Ok(content) => match serde_json::from_str::<PersistedSessionMemoryState>(&content) {
+                Ok(persisted) => {
+                    self.state.session_memory.tokens_at_last_extraction =
+                        persisted.tokens_at_last_extraction;
+                    self.state.session_memory.initialized = persisted.initialized;
+                    self.state.session_memory.last_memory_message_id =
+                        persisted.last_memory_message_id;
+                    self.state.session_memory.last_memory_message_index =
+                        persisted.last_memory_message_index;
+                    tracing::info!(
+                        tokens_at_last_extraction = persisted.tokens_at_last_extraction,
+                        initialized = persisted.initialized,
+                        "[memory_system] 已恢复持久化的 Session Memory 状态"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "[memory_system] 解析 Session Memory 状态文件失败，使用默认状态"
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "[memory_system] 读取 Session Memory 状态文件失败，使用默认状态"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// 持久化当前 Session Memory 状态到会话目录（同步，适用于同步上下文调用）
+    ///
+    /// 在提取完成或状态变更后调用，确保 runtime 重建后能恢复提取进度。
+    pub fn save_session_memory_state_sync(&self) {
+        let state_path = self.session_memory_state_path();
+        if let Some(parent) = state_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let persisted = PersistedSessionMemoryState {
+            tokens_at_last_extraction: self.state.session_memory.tokens_at_last_extraction,
+            initialized: self.state.session_memory.initialized,
+            last_memory_message_id: self.state.session_memory.last_memory_message_id.clone(),
+            last_memory_message_index: self.state.session_memory.last_memory_message_index,
+        };
+
+        match serde_json::to_string_pretty(&persisted) {
+            Ok(content) => {
+                // 使用原子写入，防止崩溃或并发读取时得到半截 JSON
+                if let Err(e) = crate::fs_util::atomic_write(&state_path, content.as_bytes()) {
+                    tracing::warn!(
+                        error = %e,
+                        "[memory_system] 保存 Session Memory 状态失败"
+                    );
+                } else {
+                    tracing::trace!("[memory_system] Session Memory 状态已持久化");
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "[memory_system] 序列化 Session Memory 状态失败"
+                );
+            }
+        }
+    }
+
+    /// 获取 Session Memory 状态文件路径
+    fn session_memory_state_path(&self) -> PathBuf {
+        let session_dir = self.session_dir();
+        session_dir.join(".session_memory_state.json")
+    }
+
+    /// 创建 Session Memory 提取 pending 文件标记（同步，跨 runtime 可见）
+    /// 使用原子创建（create_new），返回是否成功创建。
+    /// 两个 runtime 同时调用时，只有一个能成功创建，避免并发重复提取。
+    fn touch_extraction_marker_sync(&self) -> bool {
+        let marker_path = self.extraction_pending_marker_path();
+        if let Some(parent) = marker_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let timestamp_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        // 使用 create_new(true) 实现原子创建：
+        // 文件已存在时返回 Err，只有一个调用者能成功
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker_path)
+        {
+            Ok(mut file) => {
+                use std::io::Write;
+                let _ = file.write_all(timestamp_ms.to_string().as_bytes());
+                true
+            }
+            Err(e) => {
+                tracing::debug!(
+                    error = %e,
+                    "[memory_system] 创建提取标记失败（可能已有其他 runtime 在提取）"
+                );
+                false
+            }
+        }
+    }
+
+    /// 清除 Session Memory 提取 pending 文件标记
+    fn clear_extraction_marker_sync(&self) {
+        let marker_path = self.extraction_pending_marker_path();
+        if marker_path.exists() {
+            let _ = std::fs::remove_file(&marker_path);
+        }
+    }
+
+    // ── 提取任务 Journal（stale marker 清理辅助） ──────────
+    //
+    // Journal 记录提取任务的元数据（started_at、message_count 等），用于：
+    // 1. 启动时检测孤儿 journal：通过 started_at 判断任务是否已过期
+    // 2. 过期 journal 清除对应的 stale pending marker，允许下次交互重新触发提取
+    // 注意：Journal 不存储可重放的提取参数，不是可靠恢复队列。
+    // 进程退出时正在运行的任务会丢失，只能通过 stale 机制在下次启动时清理。
+
+    /// 获取 Session Memory 提取 journal 文件路径
+    fn session_memory_journal_path(&self) -> PathBuf {
+        self.session_dir().join(".extraction_journal")
+    }
+
+    /// 获取 Auto Memory 提取 journal 文件路径
+    pub fn auto_memory_journal_path(&self, memory_type: &MemoryType) -> PathBuf {
+        self.config_dir
+            .join(format!(".extraction_journal.{}", memory_type.name()))
+    }
+
+    /// 写入 Session Memory 提取 journal
+    /// 在 spawn 前调用，记录任务元数据（用于 stale marker 检测，不是可靠恢复队列）
+    /// 包含 owner_pid 用于检测任务所属进程是否存活，避免误删长耗时任务
+    pub fn write_session_memory_journal(&self, message_count: usize) {
+        let journal_path = self.session_memory_journal_path();
+        if let Some(parent) = journal_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let journal = serde_json::json!({
+            "task_type": "session_memory",
+            "session_id": self.session_id,
+            "message_count": message_count,
+            "started_at": chrono::Utc::now().to_rfc3339(),
+            "owner_pid": std::process::id(),
+        });
+        if let Ok(content) = serde_json::to_string_pretty(&journal) {
+            if let Err(e) = crate::fs_util::atomic_write(&journal_path, content.as_bytes()) {
+                tracing::debug!(error = %e, "[memory_system] 写入 Session Memory journal 失败");
+            }
+        }
+    }
+
+    /// 清除 Session Memory 提取 journal
+    pub fn clear_session_memory_journal(&self) {
+        let journal_path = self.session_memory_journal_path();
+        if journal_path.exists() {
+            let _ = std::fs::remove_file(&journal_path);
+        }
+    }
+
+    /// 写入 Auto Memory 提取 journal（用于 stale marker 检测，不是可靠恢复队列）
+    /// 包含 owner_pid 用于检测任务所属进程是否存活，避免误删长耗时任务
+    pub fn write_auto_memory_journal(&self, memory_type: &MemoryType, message_count: usize) {
+        let journal_path = self.auto_memory_journal_path(memory_type);
+        if let Some(parent) = journal_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let journal = serde_json::json!({
+            "task_type": "auto_memory",
+            "memory_type": memory_type.name(),
+            "session_id": self.session_id,
+            "message_count": message_count,
+            "started_at": chrono::Utc::now().to_rfc3339(),
+            "owner_pid": std::process::id(),
+        });
+        if let Ok(content) = serde_json::to_string_pretty(&journal) {
+            if let Err(e) = crate::fs_util::atomic_write(&journal_path, content.as_bytes()) {
+                tracing::debug!(
+                    error = %e,
+                    memory_type = memory_type.name(),
+                    "[memory_system] 写入 Auto Memory journal 失败"
+                );
+            }
+        }
+    }
+
+    /// 清除 Auto Memory 提取 journal
+    pub fn clear_auto_memory_journal(&self, memory_type: &MemoryType) {
+        let journal_path = self.auto_memory_journal_path(memory_type);
+        if journal_path.exists() {
+            let _ = std::fs::remove_file(&journal_path);
+        }
+    }
+
+    /// 扫描并清理孤儿 journal（启动时调用）
+    ///
+    /// 检测残留的 journal 文件，仅当任务已过期（started_at 超过 stale 阈值）时
+    /// 才清除 pending marker 和 journal，允许下次交互重新触发提取。
+    /// 仍在运行的任务（journal 未过期）不会被干扰，避免误删活跃任务的 marker。
+    pub fn cleanup_orphaned_journals(&self) {
+        // Session Memory journal：使用 Layer 3 的 stale 阈值
+        let sm_journal = self.session_memory_journal_path();
+        if sm_journal.exists() {
+            let stale_threshold_ms = self.config.layer3.extraction_stale_threshold_ms;
+            if self.is_journal_stale(&sm_journal, stale_threshold_ms) {
+                tracing::warn!(
+                    path = %sm_journal.display(),
+                    stale_threshold_ms,
+                    "[memory_system] 发现过期 Session Memory journal，清除 pending marker 允许重新提取"
+                );
+                self.clear_extraction_marker_sync();
+                let _ = std::fs::remove_file(&sm_journal);
+            } else {
+                tracing::debug!(
+                    path = %sm_journal.display(),
+                    "[memory_system] Session Memory journal 仍在有效期内，保留（任务可能仍在运行）"
+                );
+            }
+        }
+
+        // Auto Memory journal 扫描：使用 Layer 5 的 stale 阈值
+        let auto_stale_threshold_ms = self.config.layer5.extraction_stale_threshold_ms;
+        if let Ok(entries) = std::fs::read_dir(&self.config_dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.starts_with(".extraction_journal.") {
+                    let journal_path = entry.path();
+                    if self.is_journal_stale(&journal_path, auto_stale_threshold_ms) {
+                        tracing::warn!(
+                            path = %journal_path.display(),
+                            stale_threshold_ms = auto_stale_threshold_ms,
+                            "[memory_system] 发现过期 Auto Memory journal，清除对应 pending marker"
+                        );
+                        // 从 journal 文件名推导 pending marker 文件名
+                        let pending_name =
+                            name_str.replace(".extraction_journal.", ".extraction_pending.");
+                        let pending_path = self.config_dir.join(&*pending_name);
+                        if pending_path.exists() {
+                            let _ = std::fs::remove_file(&pending_path);
+                        }
+                        let _ = std::fs::remove_file(&journal_path);
+                    } else {
+                        tracing::debug!(
+                            path = %journal_path.display(),
+                            "[memory_system] Auto Memory journal 仍在有效期内，保留（任务可能仍在运行）"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// 检查 journal 是否已过期
+    ///
+    /// 按优先级判断：
+    /// 1. owner_pid == 当前进程：同一进程刚启动，journal 不是孤儿 → 不清理
+    /// 2. owner_pid 对应进程仍存活（Unix: /proc/{pid}）：任务可能在运行 → 不清理
+    /// 3. 进程已死或无法判断：使用 3x stale_threshold_ms 作为清理阈值
+    ///    （3x 裕量覆盖真实 LLM/Forked 提取的耗时，避免误删长耗时任务）
+    fn is_journal_stale(&self, journal_path: &Path, stale_threshold_ms: u64) -> bool {
+        let content = match std::fs::read_to_string(journal_path) {
+            Ok(c) => c,
+            Err(_) => return true, // 无法读取视为过期
+        };
+        let journal_value: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => return true, // 无法解析视为过期
+        };
+
+        // 检查 owner_pid：如果进程仍存活，journal 不是孤儿
+        if let Some(owner_pid) = journal_value.get("owner_pid").and_then(|v| v.as_u64()) {
+            let pid = owner_pid as u32;
+            if pid == std::process::id() {
+                // 同一进程：刚启动的 runtime，journal 不是孤儿
+                return false;
+            }
+            if is_pid_alive(pid) {
+                // 进程仍在运行：任务可能仍在执行
+                tracing::debug!(pid, "[memory_system] journal owner 进程仍存活，不清理");
+                return false;
+            }
+            // 进程已死：使用 3x 阈值，比正常 stale 多一些裕量
+        }
+
+        // 无 owner_pid（旧格式 journal）或进程已死：基于时间判断
+        let started_at_str = journal_value
+            .get("started_at")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let started_at = match chrono::DateTime::parse_from_rfc3339(started_at_str) {
+            Ok(dt) => dt,
+            Err(_) => return true, // 时间格式无效视为过期
+        };
+        // 使用 3x 阈值：真实 LLM/Forked 提取可能超过单次 stale 阈值
+        let effective_threshold_ms = stale_threshold_ms * 3;
+        let elapsed = chrono::Utc::now()
+            .signed_duration_since(started_at.with_timezone(&chrono::Utc))
+            .num_milliseconds();
+        elapsed >= effective_threshold_ms as i64
+    }
+
+    /// 检查是否有未完成的 Session Memory 提取标记（跨 runtime 可见）
+    pub fn has_pending_extraction_marker(&self) -> bool {
+        self.extraction_pending_marker_path().exists()
+    }
+
+    /// 读取提取 pending 标记中存储的开始时间戳（Unix epoch 毫秒）
+    /// 返回 None 表示标记不存在或内容无法解析
+    pub fn read_extraction_marker_timestamp_ms(&self) -> Option<u64> {
+        let marker_path = self.extraction_pending_marker_path();
+        let content = std::fs::read_to_string(&marker_path).ok()?;
+        content.trim().parse().ok()
+    }
+
+    /// 获取提取 pending 标记文件路径
+    fn extraction_pending_marker_path(&self) -> PathBuf {
+        let session_dir = self.session_dir();
+        session_dir.join(".extraction_pending")
     }
 
     /// 重新加载游标状态
@@ -199,6 +556,51 @@ impl MemorySystem {
 
     /// 检查是否应该提取 Session Memory
     pub fn should_extract_session_memory(&self, messages: &[ChatMessage]) -> bool {
+        // 检查跨 runtime 可见的提取 pending 文件标记
+        // 在 Gateway/异步消息模式下，前一个 runtime 可能已被 drop，
+        // 但其后台提取任务可能仍在运行。此检查防止在新 runtime 中重复触发提取。
+        if self.has_pending_extraction_marker() {
+            let marker_path = self.extraction_pending_marker_path();
+            if let Ok(metadata) = std::fs::metadata(&marker_path) {
+                if let Ok(modified) = metadata.modified() {
+                    let stale_threshold = std::time::Duration::from_millis(
+                        self.state
+                            .session_memory
+                            .config
+                            .extraction_stale_threshold_ms,
+                    );
+                    if let Ok(elapsed) = modified.elapsed() {
+                        if elapsed < stale_threshold {
+                            // 标记未过期，前一个 runtime 的提取可能仍在进行
+                            tracing::debug!(
+                                elapsed_ms = elapsed.as_millis(),
+                                "[memory_system] 提取 pending 标记未过期，跳过重复触发"
+                            );
+                            return false;
+                        }
+                    }
+                }
+            }
+            // 标记已过期，但在清理前先检查 journal 的 owner_pid
+            // 如果 journal 显示任务所属进程仍存活，说明长耗时任务正在运行，不应删除 marker
+            let journal_path = self.session_memory_journal_path();
+            let stale_threshold_ms = self
+                .state
+                .session_memory
+                .config
+                .extraction_stale_threshold_ms;
+            if journal_path.exists() && !self.is_journal_stale(&journal_path, stale_threshold_ms) {
+                tracing::debug!(
+                    "[memory_system] Session Memory marker 虽然过期，但 journal 显示任务仍在运行，不删除"
+                );
+                return false;
+            }
+            // journal 也确认过期或不存在，安全清理 marker
+            tracing::warn!(
+                "[memory_system] 提取 pending 标记已过期且 journal 确认可清理，允许重新触发"
+            );
+            self.clear_extraction_marker_sync();
+        }
         should_extract_memory(messages, &self.state.session_memory)
     }
 
@@ -237,18 +639,59 @@ impl MemorySystem {
         self.state.session_memory.last_extracted_at = Some(std::time::Instant::now());
         self.state.session_memory.extraction_started_at = None;
         self.state.has_pending_extraction = false;
+        // 清除跨 runtime 可见的提取 pending 文件标记
+        self.clear_extraction_marker_sync();
     }
 
-    /// 标记提取开始（设置 extraction_started_at）
-    pub fn mark_extraction_started(&mut self) {
-        self.state.session_memory.extraction_started_at = Some(std::time::Instant::now());
-        self.state.has_pending_extraction = true;
+    /// Compact 后重置 Session/Auto 增量基线
+    ///
+    /// Compact 会把历史替换为短摘要，token 数和消息数大幅减少。
+    /// 如果不重置基线：
+    /// - Session Memory: `current_tokens.saturating_sub(tokens_at_last_extraction)` 会为 0
+    /// - Auto Memory: `current_count.saturating_sub(last_message_count)` 会为 0
+    ///
+    /// 导致记忆提取长期不再触发，直到压缩后历史重新长到压缩前大小。
+    pub fn reset_baselines_after_compact(&mut self, post_compact_messages: &[ChatMessage]) {
+        // Session Memory: 重置 token 基线
+        let post_compact_tokens = crate::token::estimate_messages_tokens(post_compact_messages);
+        let old_tokens = self.state.session_memory.tokens_at_last_extraction;
+        if old_tokens > post_compact_tokens {
+            tracing::info!(
+                old_tokens,
+                new_tokens = post_compact_tokens,
+                "[memory_system] Compact 后重置 Session Memory token 基线"
+            );
+            self.state.session_memory.tokens_at_last_extraction = post_compact_tokens;
+        }
+
+        // Auto Memory: 重置游标消息计数基线
+        self.cursor_manager
+            .reset_message_count_baseline(post_compact_messages.len());
+
+        // 持久化 Session Memory 状态
+        self.save_session_memory_state_sync();
     }
 
-    /// 标记提取失败（清除 extraction_started_at，保留其他状态）
+    /// 标记提取开始（先创建文件标记，成功后再设内存状态）
+    /// 返回 true 表示标记创建成功，false 表示已有其他 runtime 在提取（应跳过 spawn）
+    /// 先创建 marker 再设内存状态，失败时内存状态保持干净，避免污染
+    pub fn mark_extraction_started(&mut self) -> bool {
+        // 先原子创建跨 runtime 可见的文件标记
+        let marker_created = self.touch_extraction_marker_sync();
+        if marker_created {
+            // 标记创建成功，再设置内存状态
+            self.state.session_memory.extraction_started_at = Some(std::time::Instant::now());
+            self.state.has_pending_extraction = true;
+        }
+        marker_created
+    }
+
+    /// 标记提取失败（清除 extraction_started_at + 文件标记，保留其他状态）
     pub fn mark_extraction_failed(&mut self) {
         self.state.session_memory.extraction_started_at = None;
         self.state.has_pending_extraction = false;
+        // 清除跨 runtime 可见的文件标记
+        self.clear_extraction_marker_sync();
     }
 
     /// 获取内容替换状态
@@ -350,8 +793,12 @@ impl MemorySystem {
                 last_message_index,
                 token_count,
             );
+            // 持久化状态，确保 runtime 重建后能恢复提取进度
+            self.save_session_memory_state_sync();
         } else {
             self.mark_extraction_failed();
+            // 持久化失败状态，清除提取标记
+            self.save_session_memory_state_sync();
             tracing::warn!("[memory_system] 后台 Session Memory 提取失败，已清除提取标记");
         }
         true
@@ -434,15 +881,76 @@ impl MemorySystem {
     }
 
     /// 检查是否应该触发自动记忆提取
+    ///
+    /// 过滤掉已有 pending marker 的 memory type，避免 detached 提取仍在运行时重复 spawn。
     pub fn should_extract_auto_memory(&self, messages: &[ChatMessage]) -> Vec<MemoryType> {
         let config = crate::auto_memory::AutoMemoryConfig::from(self.config.layer5.clone());
         let current_content = crate::auto_memory::build_message_content_signature(messages);
-        crate::auto_memory::should_extract_auto_memory_with_config(
+        let mut types = crate::auto_memory::should_extract_auto_memory_with_config(
             &self.cursor_manager,
             messages.len(),
             &current_content,
             &config,
-        )
+        );
+
+        // 过滤掉已有 pending marker 的 memory type
+        // 前一个 runtime 的 detached 提取可能尚未完成并保存 cursor
+        // 使用 Layer 5 独立的 stale 阈值，避免 Layer 3 短阈值误判 Layer 5 长任务
+        let stale_threshold_ms = self.config.layer5.extraction_stale_threshold_ms;
+        types.retain(|mt| !self.has_active_auto_memory_pending(mt, stale_threshold_ms));
+
+        types
+    }
+
+    /// 检查指定 memory type 是否有活跃的 pending marker
+    /// 过期时先检查对应 journal 的 owner_pid，避免误删长耗时任务的 marker
+    fn has_active_auto_memory_pending(
+        &self,
+        memory_type: &MemoryType,
+        stale_threshold_ms: u64,
+    ) -> bool {
+        let marker_path = self.auto_memory_pending_marker_path(memory_type);
+        match std::fs::metadata(&marker_path) {
+            Ok(meta) => {
+                // 检查标记是否过期
+                let is_stale = meta
+                    .modified()
+                    .ok()
+                    .and_then(|mtime| mtime.elapsed().ok())
+                    .map(|elapsed| elapsed.as_millis() as u64 >= stale_threshold_ms)
+                    .unwrap_or(true);
+                if is_stale {
+                    // 标记已过期，但在清理前先检查 journal 的 owner_pid
+                    // 如果 journal 显示任务所属进程仍存活，说明长耗时任务正在运行，不应删除 marker
+                    let journal_path = self.auto_memory_journal_path(memory_type);
+                    if journal_path.exists()
+                        && !self.is_journal_stale(&journal_path, stale_threshold_ms)
+                    {
+                        tracing::debug!(
+                            memory_type = memory_type.name(),
+                            "[memory_system] Auto Memory marker 虽然过期，但 journal 显示任务仍在运行，不删除"
+                        );
+                        return true;
+                    }
+                    // journal 也确认过期或不存在，安全清理 marker
+                    let _ = std::fs::remove_file(&marker_path);
+                    false
+                } else {
+                    tracing::debug!(
+                        memory_type = memory_type.name(),
+                        "[memory_system] 检测到活跃的 Auto Memory pending marker，跳过提取"
+                    );
+                    true
+                }
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// 获取 Auto Memory 提取 pending 标记文件路径
+    pub fn auto_memory_pending_marker_path(&self, memory_type: &MemoryType) -> PathBuf {
+        self.config_dir
+            .join(format!(".extraction_pending.{}", memory_type.name()))
     }
 
     /// 添加后台任务句柄
@@ -607,17 +1115,47 @@ impl Drop for MemorySystem {
     }
 }
 
-/// Post-Sampling Hook 结果
+/// Post-Sampling 动作集合
+///
+/// 支持同一轮返回多个动作，避免 Session/Auto/Compact 同时到期时互相跳过。
+/// 执行顺序：Session Memory → Auto Memory → Compact
 #[derive(Debug)]
-pub enum PostSamplingAction {
-    /// 无操作
-    None,
-    /// 触发 Session Memory 提取
-    ExtractSessionMemory,
-    /// 触发自动记忆提取
-    ExtractAutoMemory(Vec<MemoryType>),
-    /// 触发 Compact
-    Compact,
+pub struct PostSamplingActions {
+    /// 是否触发 Session Memory 提取
+    pub session_memory: bool,
+    /// 需要提取的 Auto Memory 类型（空 = 不触发）
+    pub auto_memory_types: Vec<MemoryType>,
+    /// 是否触发 Compact
+    pub compact: bool,
+}
+
+impl PostSamplingActions {
+    /// 所有动作均为空
+    pub fn is_empty(&self) -> bool {
+        !self.session_memory && self.auto_memory_types.is_empty() && !self.compact
+    }
+}
+
+/// 检查指定 PID 的进程是否仍存活
+///
+/// 用于 journal cleanup 判断：owner 进程仍存活说明任务可能在运行，不应清理。
+/// - 同一进程：直接返回 true
+/// - Unix: 检查 /proc/{pid} 是否存在
+/// - Windows: 无法简单检查（需要额外依赖），返回 false，依靠 3x 阈值裕量
+fn is_pid_alive(pid: u32) -> bool {
+    if pid == std::process::id() {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        std::path::Path::new(&format!("/proc/{}", pid)).exists()
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows 下无法无依赖检查 PID 存活，依靠 is_journal_stale 的 3x 阈值裕量
+        let _ = pid;
+        false
+    }
 }
 
 /// 检查是否应该触发记忆操作
@@ -635,7 +1173,7 @@ pub async fn evaluate_memory_hooks(
     memory_system: &mut MemorySystem,
     messages: &[ChatMessage],
     current_tokens: usize,
-) -> PostSamplingAction {
+) -> PostSamplingActions {
     // 检查是否需要重新加载游标状态（后台提取完成后）
     if memory_system.check_and_clear_cursor_reload() {
         if let Err(e) = memory_system.reload_cursors().await {
@@ -646,27 +1184,40 @@ pub async fn evaluate_memory_hooks(
     // 检查并应用后台 Session Memory 提取结果
     memory_system.apply_session_memory_result();
 
-    // 1. 检查 Compact (最高优先级)
-    if memory_system.should_compact(current_tokens) {
-        return PostSamplingAction::Compact;
-    }
+    // 收集所有需要触发的动作（不提前 return，确保 Session/Auto/Compact 同时到期时都不被跳过）
+    let mut actions = PostSamplingActions {
+        session_memory: false,
+        auto_memory_types: Vec::new(),
+        compact: false,
+    };
 
-    // 2. 检查 Session Memory 提取
+    // 1. 检查 Session Memory 提取（在 Compact 之前，确保压缩前完成会话记忆快照）
+    // 设计文档 Post-Sampling 顺序：Layer 3/5 先于 Layer 4
+    // 如果长会话首次达到 compact 阈值但还没提取 Session Memory，
+    // 必须先提取再压缩，否则压缩后原始长历史丢失，Layer 3 再也无法提取
     if memory_system.should_extract_session_memory(messages) {
-        return PostSamplingAction::ExtractSessionMemory;
+        actions.session_memory = true;
     }
 
-    // 3. 检查自动记忆提取
+    // 2. 检查自动记忆提取（在 Compact 之前，确保压缩前用完整历史提取）
+    // 设计文档 Post-Sampling 顺序：Layer 3/5 先于 Layer 4
+    // Auto Memory 需要完整历史作为提取材料，必须在压缩前执行，
+    // 否则压缩后 history 被替换为摘要，提取质量下降或完全丢失
     if memory_system.config().auto_memory_enabled {
         // 使用已加载的 cursor_manager，确保冷却机制正确工作
         let types_to_extract = memory_system.should_extract_auto_memory(messages);
 
         if !types_to_extract.is_empty() {
-            return PostSamplingAction::ExtractAutoMemory(types_to_extract);
+            actions.auto_memory_types = types_to_extract;
         }
     }
 
-    PostSamplingAction::None
+    // 3. 检查 Compact（Layer 3/5 都不需要时也检查，支持同轮组合触发）
+    if memory_system.should_compact(current_tokens) {
+        actions.compact = true;
+    }
+
+    actions
 }
 
 /// 默认记忆目录路径
@@ -760,8 +1311,8 @@ mod tests {
 
         let messages = vec![ChatMessage::user("Hello"), ChatMessage::assistant("Hi!")];
 
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
-        assert!(matches!(action, PostSamplingAction::None));
+        let actions = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
+        assert!(actions.is_empty());
     }
 
     #[tokio::test]
@@ -782,9 +1333,9 @@ mod tests {
         );
 
         let messages = vec![ChatMessage::user("Test")];
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
+        let actions = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
-        assert!(matches!(action, PostSamplingAction::Compact));
+        assert!(actions.compact);
     }
 
     #[test]
@@ -899,7 +1450,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_post_sampling_action_order() {
-        // 测试 Compact 优先级高于其他操作
+        // 测试 Post-Sampling 优先级：Session Memory > Auto Memory > Compact
+        // 设计文档要求 Layer 3/5 先于 Layer 4，确保压缩前完成提取
         let config = MemorySystemConfig {
             token_budget: 100,
             layer4: Layer4Config {
@@ -916,7 +1468,7 @@ mod tests {
             "test".to_string(),
         );
 
-        // 即使有足够的消息触发 auto memory，也应该优先返回 Compact
+        // 有足够消息触发 auto memory，且 auto memory 优先级高于 Compact
         let messages: Vec<ChatMessage> = (0..20)
             .flat_map(|i| {
                 vec![
@@ -926,9 +1478,13 @@ mod tests {
             })
             .collect();
 
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
+        let actions = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
-        // Compact 优先级最高
-        assert!(matches!(action, PostSamplingAction::Compact));
+        // Auto Memory 和 Compact 可以同时触发（设计文档：Layer 3/5 先于 Layer 4）
+        assert!(
+            !actions.auto_memory_types.is_empty(),
+            "Auto Memory 应被触发，实际: {:?}",
+            actions
+        );
     }
 }

--- a/crates/agent/src/runtime.rs
+++ b/crates/agent/src/runtime.rs
@@ -2589,15 +2589,19 @@ impl AgentRuntime {
         // Use paths.base as both workspace and config directory
         let base_dir = self.paths.base.clone();
 
-        // 增加梦境会话门控计数（Layer 6）
-        // 每次新会话初始化时递增，使 Dream 整合的三重门控机制能正确判断
-        // 注意：由于 agent 和 scheduler 存在循环依赖，此处直接操作 .dream_state.json
-        crate::dream_state::increment_dream_session_count(&base_dir).await;
+        // 注意：Dream session count 不再在此处无条件递增。
+        // 改为在 process_message 中根据会话是否为全新创建来决定是否递增，
+        // 避免 Gateway/异步消息模式下每条消息都错误推进 Dream 门控。
+        // 参见 process_message 中 is_new_session 的判断逻辑。
 
         let mut memory_system = MemorySystem::new(config, base_dir.clone(), base_dir, session_id);
 
         // Perform async initialization: load cursor state + mark session active
         memory_system.initialize().await?;
+
+        // 扫描并清理过期 journal（上次进程退出时遗留的未完成任务）
+        // 仅清理超过 stale 阈值的 journal 及其 pending marker，保留仍在运行的任务
+        memory_system.cleanup_orphaned_journals();
 
         // 仅当用户显式写了 circuitBreaker 时才覆盖分层默认值。
         {
@@ -2991,6 +2995,34 @@ impl AgentRuntime {
         // ========== 0. Memory Flush — 压缩前保存重要信息 ==========
         self.flush_memory_store_before_compact(messages).await;
 
+        // ========== 0.5. Pre-Compact Hooks ==========
+        // 允许注册的 hooks 在压缩前执行自定义逻辑（取消、延迟等）
+        if let Some(ms) = self.memory_system.as_ref() {
+            if ms.compact_hooks().has_pre_hooks() {
+                let token_budget = ms.config().token_budget;
+                let pre_ctx = crate::compact::PreCompactContext {
+                    session_id: _session_key.to_string(),
+                    current_tokens: pre_compact_tokens,
+                    budget_tokens: token_budget,
+                    has_pending_background_tasks: ms.has_pending_extraction(),
+                };
+                match ms.compact_hooks().execute_pre_hooks(pre_ctx).await {
+                    crate::compact::PreCompactResult::Cancel => {
+                        info!("[layer4] Compact cancelled by pre-hook");
+                        return CompactResult::failed("Cancelled by pre-hook");
+                    }
+                    crate::compact::PreCompactResult::Delay(duration) => {
+                        info!(
+                            delay_ms = duration.as_millis() as u64,
+                            "[layer4] Compact delayed by pre-hook"
+                        );
+                        tokio::time::sleep(duration).await;
+                    }
+                    crate::compact::PreCompactResult::Continue => {}
+                }
+            }
+        }
+
         // ========== 1. 熔断器检查 ==========
         let circuit_breaker = get_compact_circuit_breaker();
         if !circuit_breaker.allow() {
@@ -3088,8 +3120,55 @@ impl AgentRuntime {
         // ========== 7. 收集恢复信息 ==========
         // 先等待后台 Session Memory 提取完成，避免读取过时内容
         if let Some(memory_system) = self.memory_system.as_ref() {
+            // 检查跨 runtime 可见的提取 pending 标记
+            // 在 gateway/异步消息模式下，前一个 runtime 的提取可能仍在运行
+            // 但其 extraction_started_at (Instant) 在当前 runtime 中为 None
+            let has_cross_runtime_pending = memory_system.has_pending_extraction_marker();
             let extraction_started_at = memory_system.session_memory_state().extraction_started_at;
-            if extraction_started_at.is_some() {
+
+            // 如果有跨 runtime pending 标记且不是过期的，使用 marker 中存储的时间戳
+            // 构造准确的 started_at，避免使用 Instant::now() 导致无意义超时
+            let effective_started_at = if extraction_started_at.is_some() {
+                extraction_started_at
+            } else if has_cross_runtime_pending {
+                let stale_threshold_ms =
+                    memory_system.config().layer3.extraction_stale_threshold_ms;
+                let marker_path = memory_system.session_dir().join(".extraction_pending");
+                // 读取 marker 中存储的 Unix epoch 毫秒时间戳
+                let marker_ts_ms = memory_system.read_extraction_marker_timestamp_ms();
+                let is_stale = marker_ts_ms
+                    .map(|ts_ms| {
+                        let now_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64;
+                        now_ms.saturating_sub(ts_ms) >= stale_threshold_ms
+                    })
+                    .unwrap_or(true);
+                if is_stale {
+                    // 标记已过期，清理并跳过等待
+                    let _ = std::fs::remove_file(&marker_path);
+                    None
+                } else {
+                    info!("[layer4] 检测到跨 runtime 提取 pending 标记，等待提取完成");
+                    // 从 marker 时间戳恢复准确的 Instant，避免从 Instant::now() 开始导致的无意义超时
+                    marker_ts_ms.and_then(|ts_ms| {
+                        let now_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .ok()?
+                            .as_millis() as u64;
+                        let elapsed_ms = now_ms.saturating_sub(ts_ms);
+                        Some(
+                            std::time::Instant::now()
+                                - std::time::Duration::from_millis(elapsed_ms),
+                        )
+                    })
+                }
+            } else {
+                None
+            };
+
+            if effective_started_at.is_some() {
                 let wait_timeout_ms = memory_system.config().layer3.extraction_wait_timeout_ms;
                 let stale_threshold_ms =
                     memory_system.config().layer3.extraction_stale_threshold_ms;
@@ -3099,7 +3178,7 @@ impl AgentRuntime {
                 );
                 match crate::session_memory::recovery::wait_for_session_memory_extraction_with_timeout(
                     &session_memory_path,
-                    extraction_started_at,
+                    effective_started_at,
                     wait_timeout_ms,
                     stale_threshold_ms,
                 )
@@ -3114,7 +3193,7 @@ impl AgentRuntime {
             }
         }
 
-        let recovery_message = if let Some(memory_system) = self.memory_system.as_ref() {
+        let mut recovery_message = if let Some(memory_system) = self.memory_system.as_ref() {
             let session_memory_path =
                 get_session_memory_path(memory_system.workspace_dir(), memory_system.session_id());
             let session_memory_content =
@@ -3129,13 +3208,57 @@ impl AgentRuntime {
             String::new()
         };
 
-        // ========== 8. 构建 CompactResult ==========
-        let post_compact_tokens = estimate_messages_tokens(&[
+        // ========== 8. 构建 CompactResult（初始 token 估算） ==========
+        let mut post_compact_tokens = estimate_messages_tokens(&[
             ChatMessage::system(&summary_message),
             ChatMessage::user(&recovery_message),
         ]);
 
-        // ========== 9. 记录成功事件 ==========
+        // ========== 9. Post-Compact Hooks ==========
+        // 允许注册的 hooks 在压缩完成后执行恢复/清理逻辑
+        // 注意：post-hooks 可能追加 recovery 内容并更新 post_compact_tokens，
+        // 因此指标记录必须在 post-hooks 之后，确保 token 指标准确
+        if let Some(ms) = self.memory_system.as_ref() {
+            if ms.compact_hooks().has_post_hooks() {
+                let session_memory_path = crate::session_memory::get_session_memory_path(
+                    ms.workspace_dir(),
+                    ms.session_id(),
+                );
+                let post_ctx = crate::compact::PostCompactContext {
+                    session_id: _session_key.to_string(),
+                    recovery_message: recovery_message.clone(),
+                    session_memory_path: if session_memory_path.exists() {
+                        Some(session_memory_path)
+                    } else {
+                        None
+                    },
+                };
+                match ms.compact_hooks().execute_post_hooks(post_ctx).await {
+                    crate::compact::PostCompactResult::NeedRecovery(hook_recovery) => {
+                        warn!(
+                            recovery_msg = %hook_recovery,
+                            "[layer4] Post-compact hook requested recovery, 追加恢复消息"
+                        );
+                        // NeedRecovery 语义为"额外恢复"，应追加而非替换
+                        // 保留 generate_compact_recovery() 收集的文件/技能/session recovery
+                        if !hook_recovery.is_empty() {
+                            if !recovery_message.is_empty() {
+                                recovery_message.push_str("\n\n");
+                            }
+                            recovery_message.push_str(&hook_recovery);
+                            // hook 注入后重新计算 token 数
+                            post_compact_tokens = estimate_messages_tokens(&[
+                                ChatMessage::system(&summary_message),
+                                ChatMessage::user(&recovery_message),
+                            ]);
+                        }
+                    }
+                    crate::compact::PostCompactResult::Success => {}
+                }
+            }
+        }
+
+        // ========== 10. 记录成功事件（post-hooks 之后，token 指标准确） ==========
         // 使用来自 LLM API 响应的真实 cache usage 数据
         crate::memory_event!(
             layer4,
@@ -3960,9 +4083,11 @@ impl AgentRuntime {
         info!(target: "chat::user", content = %msg.content, "User input");
         self.update_main_session_target(&msg).await;
         if let Some(manager) = self.ghost_memory_lifecycle.as_ref() {
+            // cron 投递场景下使用 persist_session_key（目标会话），
+            // 确保学习/召回归属到目标会话而非源会话
             let turn_number = self
                 .session_store
-                .load(&session_key)
+                .load(&persist_session_key)
                 .map(|history| {
                     history
                         .iter()
@@ -3971,7 +4096,7 @@ impl AgentRuntime {
                         + 1
                 })
                 .unwrap_or(1);
-            manager.on_turn_start(turn_number, &msg.content, &session_key);
+            manager.on_turn_start(turn_number, &msg.content, &persist_session_key);
         }
 
         // Learning Coordinator: record user turn (replaces skill_nudge_engine.record_user_turn)
@@ -4095,7 +4220,7 @@ impl AgentRuntime {
         // ── Handle manual compact request from /compact command ──
         if msg.content == "__COMPACT_REQUEST__" {
             info!(
-                session_key = %session_key,
+                session_key = %persist_session_key,
                 channel = %msg.channel,
                 "[compact] Manual compact request received"
             );
@@ -4106,18 +4231,19 @@ impl AgentRuntime {
                 account_id: msg.account_id.as_deref(),
             };
 
-            // Load session history for compact
-            let history = self.session_store.load(&session_key)?;
+            // 使用 persist_session_key 加载和保存历史：cron 转发场景下
+            // persist_session_key 是目标会话，session_key 是来源会话
+            let history = self.session_store.load(&persist_session_key)?;
             if let Err(e) = self
-                .capture_pre_compress_learning_boundary(&session_key, &history)
+                .capture_pre_compress_learning_boundary(&persist_session_key, &history)
                 .await
             {
-                warn!(error = %e, session_key = %session_key, "Ghost learning pre-compress capture failed");
+                warn!(error = %e, session_key = %persist_session_key, "Ghost learning pre-compress capture failed");
             }
 
             // Execute compact directly (is_auto=false for manual trigger)
             let result = self
-                .execute_layer4_compact(&history, &session_key, Some(compact_ctx), false)
+                .execute_layer4_compact(&history, &persist_session_key, Some(compact_ctx), false)
                 .await;
 
             if result.success {
@@ -4127,12 +4253,15 @@ impl AgentRuntime {
                     ChatMessage::user("请继续当前任务。"),
                 ];
                 compacted_messages.extend(result.recent_messages);
-                self.session_store.save(&session_key, &compacted_messages)?;
+                self.session_store
+                    .save(&persist_session_key, &compacted_messages)?;
 
                 // Clear trackers
                 if let Some(ms) = self.memory_system.as_mut() {
                     ms.file_tracker_mut().clear();
                     ms.skill_tracker_mut().clear();
+                    // 重置 Session/Auto 增量基线，避免压缩后永远不触发记忆提取
+                    ms.reset_baselines_after_compact(&compacted_messages);
                 }
 
                 // Record compression metrics
@@ -4210,9 +4339,28 @@ impl AgentRuntime {
             return Ok(String::new());
         }
 
-        // Load session history
-        let mut history = self.session_store.load(&session_key)?;
+        // 使用 persist_session_key 加载历史：cron 转发场景下 persist_session_key 是目标会话，
+        // session_key 是来源会话。历史应从目标会话加载，避免源会话历史覆盖目标会话。
+        let mut history = self.session_store.load(&persist_session_key)?;
         let mut session_metadata = self.session_store.load_metadata(&persist_session_key)?;
+
+        // Dream session count：使用独立 marker 文件 + create_new 实现原子计数
+        // 解决 metadata save 的 TOCTOU 竞态：两个 runtime 可能同时读到 dream_counted=false，
+        // 都执行 save_with_metadata（File::create 覆盖写），导致重复递增。
+        // mark_dream_counted 使用 create_new(true) 创建独立 marker 文件，只有一个调用者能成功。
+        if self.session_store.mark_dream_counted(&persist_session_key) {
+            if let Err(e) =
+                crate::dream_state::increment_dream_session_count(&self.paths.base).await
+            {
+                warn!(
+                    error = %e,
+                    session_key = %persist_session_key,
+                    "[dream] 会话计数递增失败，清除 marker 以便重试"
+                );
+                self.session_store
+                    .clear_dream_counted_marker(&persist_session_key);
+            }
+        }
         if let Err(err) = self.apply_learned_skill_negative_feedback(&mut session_metadata, &msg) {
             warn!(
                 error = %err,
@@ -4223,9 +4371,13 @@ impl AgentRuntime {
 
         // Layer 2: 时间触发的轻量压缩
         // 检查会话最后更新时间，如果超过阈值则清理旧工具结果
+        // 注意：updated_at 存储在 session 文件外层 metadata 行中，不在 metadata 子对象内，
+        // 必须使用 load_timestamps() 而非从 session_metadata 读取
         let time_config = TimeBasedMCConfig::from(self.config.memory.memory_system.layer2.clone());
-        if let Some(updated_at_str) = session_metadata.get("updated_at").and_then(|v| v.as_str()) {
-            if let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(updated_at_str) {
+        if let Ok((_, Some(updated_at_str))) =
+            self.session_store.load_timestamps(&persist_session_key)
+        {
+            if let Ok(updated_at) = chrono::DateTime::parse_from_rfc3339(&updated_at_str) {
                 let last_assistant_timestamp = Some(updated_at.with_timezone(&chrono::Utc));
                 let projector = HistoryProjector::new(&history);
 
@@ -4250,7 +4402,7 @@ impl AgentRuntime {
         if history.is_empty() {
             if let Some(new_name) = self
                 .session_store
-                .set_session_name_if_new(&session_key, &msg.content)
+                .set_session_name_if_new(&persist_session_key, &msg.content)
             {
                 if msg.channel == "ws" {
                     if let Some(ref event_tx) = self.event_tx {
@@ -4409,10 +4561,12 @@ impl AgentRuntime {
             .get("media_pending_intent")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        // 使用 persist_session_key 构建上下文：cron delivery 下 file memory snapshot
+        // 应基于目标会话而非来源会话
         let mut messages = self
             .context_builder
             .build_messages_for_session_mode_with_channel(
-                &session_key,
+                &persist_session_key,
                 &history,
                 &msg.content,
                 &msg.media,
@@ -4442,13 +4596,16 @@ impl AgentRuntime {
         history.push(ChatMessage::user(&msg.content));
 
         // Layer 4: Initialize memory system if needed
+        // 使用 persist_session_key（非 session_key）：cron delivery/转发场景下
+        // Session Memory 文件、pending marker、.session_memory_state.json
+        // 应写入目标会话目录，而非来源会话
         let needs_memory_system_init = self
             .memory_system
             .as_ref()
-            .map(|memory_system| memory_system.session_id() != session_key)
+            .map(|memory_system| memory_system.session_id() != persist_session_key)
             .unwrap_or(true);
         if needs_memory_system_init {
-            if let Err(e) = self.init_memory_system(session_key.clone()).await {
+            if let Err(e) = self.init_memory_system(persist_session_key.clone()).await {
                 warn!(error = %e, "[layer4] Failed to initialize memory system");
             }
         }
@@ -4567,13 +4724,15 @@ impl AgentRuntime {
                     // 使用 self.paths.workspace() 而非 self.paths.base，
                     // 保证写入的 .tool_results 目录与 session_recall 读取、
                     // cleanup_tool_results 清理共用同一个根目录（base/workspace/.tool_results）
+                    // 使用 persist_session_key：cron delivery 下 history 来自目标会话，
+                    // 大工具结果也应写入目标会话目录，否则后续 session_recall 找不到
                     current_messages = crate::response_cache::apply_budget_async(
                         &current_messages,
                         &candidates,
                         &mut state_mut,
                         budget,
                         &self.paths.workspace(),
-                        &session_key,
+                        &persist_session_key,
                         preview_size_chars,
                     )
                     .await;
@@ -4613,26 +4772,30 @@ impl AgentRuntime {
                         account_id: msg.account_id.as_deref(),
                     };
                     if let Err(e) = self
-                        .capture_pre_compress_learning_boundary(&session_key, &current_messages)
+                        .capture_pre_compress_learning_boundary(
+                            &persist_session_key,
+                            &current_messages,
+                        )
                         .await
                     {
-                        warn!(error = %e, session_key = %session_key, "Ghost learning pre-compress capture failed");
+                        warn!(error = %e, session_key = %persist_session_key, "Ghost learning pre-compress capture failed");
                     }
                     let compact_result = self
                         .execute_layer4_compact(
                             &current_messages,
-                            &session_key,
+                            &persist_session_key,
                             Some(compact_ctx),
                             true, // is_auto for automatic compact
                         )
                         .await;
                     if compact_result.success {
+                        // 替换当前消息为压缩后的内容（用于 LLM API 调用）
                         current_messages.clear();
                         current_messages
                             .push(ChatMessage::system(&compact_result.to_compact_message()));
                         current_messages.push(ChatMessage::user("请继续当前任务。"));
 
-                        current_messages.extend(compact_result.recent_messages);
+                        current_messages.extend(compact_result.recent_messages.clone());
 
                         info!(
                             post_compact_tokens = estimate_messages_tokens(&current_messages),
@@ -4640,10 +4803,22 @@ impl AgentRuntime {
                         );
                         metrics.record_compression();
 
+                        // 同步更新 history 并持久化到 session store
+                        // 确保 compact 结果在请求中断或失败时也不会丢失
+                        history.clear();
+                        history.push(ChatMessage::system(&compact_result.to_compact_message()));
+                        history.push(ChatMessage::user("请继续当前任务。"));
+                        history.extend(compact_result.recent_messages);
+                        if let Err(e) = self.session_store.save(&persist_session_key, &history) {
+                            warn!(error = %e, "[layer4] 无法保存 pre-loop compacted history");
+                        }
+
                         // Compact 成功后清空追踪器，防止下次 Compact 重复恢复
                         if let Some(ms) = self.memory_system.as_mut() {
                             ms.file_tracker_mut().clear();
                             ms.skill_tracker_mut().clear();
+                            // 重置 Session/Auto 增量基线，避免压缩后永远不触发记忆提取
+                            ms.reset_baselines_after_compact(&history);
                         }
                     } else {
                         warn!(
@@ -5219,28 +5394,31 @@ impl AgentRuntime {
                             account_id: msg.account_id.as_deref(),
                         };
                         if let Err(e) = self
-                            .capture_pre_compress_learning_boundary(&session_key, &current_messages)
+                            .capture_pre_compress_learning_boundary(
+                                &persist_session_key,
+                                &current_messages,
+                            )
                             .await
                         {
-                            warn!(error = %e, session_key = %session_key, "Ghost learning pre-compress capture failed");
+                            warn!(error = %e, session_key = %persist_session_key, "Ghost learning pre-compress capture failed");
                         }
                         let compact_result = self
                             .execute_layer4_compact(
                                 &current_messages,
-                                &session_key,
+                                &persist_session_key,
                                 Some(compact_ctx),
                                 true, // is_auto for automatic compact
                             )
                             .await;
                         if compact_result.success {
-                            // 替换消息历史为压缩后的内容
+                            // 替换消息历史为压缩后的内容（用于 LLM API 调用）
                             current_messages.clear();
                             current_messages
                                 .push(ChatMessage::system(&compact_result.to_compact_message()));
                             // 添加当前用户消息作为继续点
                             current_messages.push(ChatMessage::user("请继续当前任务。"));
 
-                            current_messages.extend(compact_result.recent_messages);
+                            current_messages.extend(compact_result.recent_messages.clone());
 
                             info!(
                                 post_compact_tokens = estimate_messages_tokens(&current_messages),
@@ -5248,10 +5426,23 @@ impl AgentRuntime {
                             );
                             metrics.record_compression();
 
+                            // 同步更新 history 并持久化到 session store
+                            // 确保 compact 结果不会因请求中断而丢失
+                            history.clear();
+                            history.push(ChatMessage::system(&compact_result.to_compact_message()));
+                            history.push(ChatMessage::user("请继续当前任务。"));
+                            history.extend(compact_result.recent_messages);
+                            if let Err(e) = self.session_store.save(&persist_session_key, &history)
+                            {
+                                warn!(error = %e, "[layer4] 无法保存 mid-loop compacted history");
+                            }
+
                             // Compact 成功后清空追踪器，防止下次 Compact 重复恢复
                             if let Some(ms) = self.memory_system.as_mut() {
                                 ms.file_tracker_mut().clear();
                                 ms.skill_tracker_mut().clear();
+                                // 重置 Session/Auto 增量基线，避免压缩后永远不触发记忆提取
+                                ms.reset_baselines_after_compact(&history);
                             }
 
                             // 跳过后续处理
@@ -5611,47 +5802,57 @@ impl AgentRuntime {
 
         if let Some(memory_system) = self.memory_system.as_mut() {
             let current_tokens = estimate_messages_tokens(&history);
-            let action = crate::memory_system::evaluate_memory_hooks(
+            let mut actions = crate::memory_system::evaluate_memory_hooks(
                 memory_system,
                 &history,
                 current_tokens,
             )
             .await;
 
-            match action {
-                crate::memory_system::PostSamplingAction::ExtractSessionMemory => {
-                    info!("[post-sampling] Spawning Session Memory extraction task");
+            // Post-Sampling 动作处理：Session Memory → Auto Memory → Compact
+            // 使用 PostSamplingActions struct 支持同一轮返回多个动作，
+            // 避免 Session/Auto/Compact 同时到期时互相跳过。
+            // 执行顺序：先 spawn 提取任务（clone 历史），再同步执行 Compact。
 
-                    // 先确保 session memory 文件存在于磁盘上，
-                    // 必须在 mark_extraction_started() 之前完成，
-                    // 否则模板写入的 mtime 会晚于 extraction_start_system，
-                    // 导致 compact 等待时误判提取已完成
-                    let memory_path = crate::session_memory::get_session_memory_path(
-                        memory_system.workspace_dir(),
-                        memory_system.session_id(),
-                    );
-                    let template = crate::session_memory::DEFAULT_SESSION_MEMORY_TEMPLATE;
-                    match crate::session_memory::setup_session_memory_file(&memory_path, template)
-                        .await
-                    {
-                        Ok(_) => {
-                            info!(
-                                path = %memory_path.display(),
-                                "[layer3] Session memory file ensured on disk"
-                            );
-                        }
-                        Err(e) => {
-                            warn!(
-                                path = %memory_path.display(),
-                                error = %e,
-                                "[layer3] Failed to initialize session memory file"
-                            );
-                        }
+            // 1. Session Memory 提取
+            if actions.session_memory {
+                info!("[post-sampling] Spawning Session Memory extraction task");
+
+                // 先确保 session memory 文件存在于磁盘上，
+                // 必须在 mark_extraction_started() 之前完成，
+                // 否则模板写入的 mtime 会晚于 extraction_start_system，
+                // 导致 compact 等待时误判提取已完成
+                let memory_path = crate::session_memory::get_session_memory_path(
+                    memory_system.workspace_dir(),
+                    memory_system.session_id(),
+                );
+                let template = crate::session_memory::DEFAULT_SESSION_MEMORY_TEMPLATE;
+                match crate::session_memory::setup_session_memory_file(&memory_path, template).await
+                {
+                    Ok(_) => {
+                        info!(
+                            path = %memory_path.display(),
+                            "[layer3] Session memory file ensured on disk"
+                        );
                     }
+                    Err(e) => {
+                        warn!(
+                            path = %memory_path.display(),
+                            error = %e,
+                            "[layer3] Failed to initialize session memory file"
+                        );
+                    }
+                }
 
-                    // 标记提取开始（设置 extraction_started_at + has_pending_extraction）
-                    // 在模板写入之后，这样 mtime 基准不会被模板写入干扰
-                    memory_system.mark_extraction_started();
+                // 标记提取开始（设置 extraction_started_at + has_pending_extraction）
+                // 在模板写入之后，这样 mtime 基准不会被模板写入干扰
+                // 原子创建 pending marker：如果另一个 runtime 已在提取，跳过 spawn
+                if !memory_system.mark_extraction_started() {
+                    info!("[layer3] 另一个 runtime 已在提取 Session Memory，跳过");
+                } else {
+                    // 落盘 journal：记录任务元数据，用于 stale marker 检测
+                    // 后台任务完成时清除 journal；不是可靠恢复队列
+                    memory_system.write_session_memory_journal(history.len());
 
                     // 克隆必要的数据用于异步任务
                     let provider_pool = Arc::clone(&self.provider_pool);
@@ -5669,8 +5870,29 @@ impl AgentRuntime {
                     let current_token_count =
                         crate::token::estimate_messages_tokens(&history_clone);
 
-                    // 非阻塞执行
-                    let handle = tokio::spawn(async move {
+                    // 获取状态文件和标记文件路径（用于后台任务直接落盘）
+                    // 在短生命周期 runtime 下（如 gateway 模式），runtime 可能
+                    // 在后台提取完成前被 drop，导致 watch channel 结果无法应用。
+                    // 后台任务直接写状态文件可确保下次 runtime 能恢复提取进度。
+                    let session_state_path = memory_path
+                        .parent()
+                        .map(|p| p.join(".session_memory_state.json"))
+                        .unwrap_or_else(|| memory_path.with_extension("session_memory_state.json"));
+                    let session_marker_path = memory_path
+                        .parent()
+                        .map(|p| p.join(".extraction_pending"))
+                        .unwrap_or_else(|| memory_path.with_extension("extraction_pending"));
+                    // journal 路径：后台任务完成时清除
+                    let session_journal_path = memory_path
+                        .parent()
+                        .map(|p| p.join(".extraction_journal"))
+                        .unwrap_or_else(|| memory_path.with_extension("extraction_journal"));
+
+                    // 非阻塞执行（不追踪 handle，避免 runtime drop 时被 abort）
+                    // 可靠性说明：journal 仅用于 stale marker 检测，不是可靠恢复队列。
+                    // 进程退出时正在运行的任务会丢失，只能通过 stale 机制清理。
+                    // 原子 pending marker 防止并发重复提取。
+                    let _handle = tokio::spawn(async move {
                         let system_prompt = Arc::new(
                             "你是一个会话记忆提取助手。请从对话中提取关键信息并更新 Session Memory 文件。"
                                 .to_string(),
@@ -5697,7 +5919,7 @@ impl AgentRuntime {
                             Ok(_) => {
                                 info!("[layer3] Session Memory extraction completed");
                                 crate::memory_system::SessionMemoryExtractionResult {
-                                    last_message_id: last_msg_id,
+                                    last_message_id: last_msg_id.clone(),
                                     last_message_index: last_msg_index,
                                     token_count: current_token_count,
                                     success: true,
@@ -5711,95 +5933,202 @@ impl AgentRuntime {
                                 }
                             }
                         };
-                        let _ = result_sender.send(extraction_result);
+                        let _ = result_sender.send(extraction_result.clone());
+
+                        // 直接持久化状态到文件，确保短生命周期 runtime 下状态不丢失
+                        // 即使当前 runtime 已被 drop，下次 runtime 也能从文件恢复提取进度
+                        if extraction_result.success {
+                            let json = serde_json::json!({
+                                "tokens_at_last_extraction": current_token_count,
+                                "initialized": true,
+                                "last_memory_message_id": last_msg_id,
+                                "last_memory_message_index": last_msg_index,
+                            });
+                            if let Ok(content) = serde_json::to_string_pretty(&json) {
+                                if let Some(parent) = session_state_path.parent() {
+                                    let _ = std::fs::create_dir_all(parent);
+                                }
+                                // 使用原子写入，防止崩溃或并发读取时得到半截 JSON
+                                if let Err(e) = crate::fs_util::atomic_write(
+                                    &session_state_path,
+                                    content.as_bytes(),
+                                ) {
+                                    tracing::warn!(
+                                        error = %e,
+                                        path = %session_state_path.display(),
+                                        "[layer3] 直接持久化状态文件失败"
+                                    );
+                                }
+                            }
+                        }
+                        // 始终清理 extraction pending 标记和 journal（无论成功或失败）
+                        let _ = std::fs::remove_file(&session_marker_path);
+                        let _ = std::fs::remove_file(&session_journal_path);
                     });
 
-                    // 保存任务句柄
-                    if let Some(ms) = self.memory_system.as_mut() {
-                        ms.add_background_task(handle);
+                    // 注意：不将提取句柄加入 background_tasks，避免 runtime drop 时 abort
+                    // 导致状态永远无法落盘。后台任务自行写状态文件 + 清标记，对 runtime
+                    // 生命周期无依赖。tokio::spawn 的任务会持续运行直到完成。
+                } // else: mark_extraction_started 成功
+            }
+
+            // 2. Auto Memory 提取
+            if !actions.auto_memory_types.is_empty() {
+                info!(
+                    memory_types = ?actions.auto_memory_types,
+                    "[post-sampling] Spawning Auto Memory extraction tasks"
+                );
+
+                // 克隆必要的数据
+                let provider_pool = Arc::clone(&self.provider_pool);
+                let history_clone = history.clone();
+                let config_dir = memory_system.config_dir().to_path_buf();
+                let model = self.config.agents.defaults.model.clone();
+                let layer5_config = memory_system.config().layer5.clone();
+                // 使用预先获取的 cursor_reload_flag
+                let cursor_reload_flag = cursor_reload_flag
+                    .clone()
+                    .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)));
+
+                // 为每种记忆类型创建独立的异步任务
+                for memory_type in actions.auto_memory_types.drain(..) {
+                    let provider_pool_for_type = Arc::clone(&provider_pool);
+                    let history_for_type = history_clone.clone();
+                    let config_dir_for_type = config_dir.clone();
+                    let model_for_type = model.clone();
+                    let layer5_config_for_type = layer5_config.clone();
+                    let reload_flag_for_type = Arc::clone(&reload_flag);
+                    let cursor_reload_flag_for_type = Arc::clone(&cursor_reload_flag);
+
+                    // 获取最后一条用户消息的 UUID（用于游标更新）
+                    let last_user_uuid = history_for_type
+                        .iter()
+                        .rev()
+                        .find(|m| m.role == "user")
+                        .and_then(|m| m.id.clone())
+                        .and_then(|s| uuid::Uuid::parse_str(&s).ok())
+                        .unwrap_or_else(uuid::Uuid::new_v4);
+
+                    let message_count = history_for_type.len();
+
+                    // per-memory-type pending marker 路径
+                    let auto_marker_path = config_dir_for_type
+                        .join(format!(".extraction_pending.{}", memory_type.name()));
+                    // per-memory-type journal 路径
+                    let auto_journal_path = config_dir_for_type
+                        .join(format!(".extraction_journal.{}", memory_type.name()));
+
+                    // 在 spawn 前同步、原子创建 pending marker，防止快连续消息重复 spawn
+                    // create_new(true) 保证只有一个调用者能成功创建文件
+                    // 已存在的 marker 说明该 memory type 的提取正在运行，应跳过
+                    if let Some(parent) = auto_marker_path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
                     }
-                }
-                crate::memory_system::PostSamplingAction::ExtractAutoMemory(types) => {
-                    info!(
-                        memory_types = ?types,
-                        "[post-sampling] Spawning Auto Memory extraction tasks"
-                    );
+                    let marker_created = std::fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(&auto_marker_path)
+                        .is_ok();
+                    if !marker_created {
+                        tracing::debug!(
+                            memory_type = memory_type.name(),
+                            "[layer5] 跳过已标记 pending 的 memory type 提取"
+                        );
+                        continue;
+                    }
 
-                    // 克隆必要的数据
-                    let provider_pool = Arc::clone(&self.provider_pool);
-                    let history_clone = history.clone();
-                    let config_dir = memory_system.config_dir().to_path_buf();
-                    let model = self.config.agents.defaults.model.clone();
-                    let layer5_config = memory_system.config().layer5.clone();
-                    // 使用预先获取的 cursor_reload_flag
-                    let cursor_reload_flag = cursor_reload_flag
-                        .clone()
-                        .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicBool::new(false)));
+                    // 落盘 journal：记录任务元数据，用于 stale marker 检测
+                    // 包含 owner_pid 用于检测任务所属进程是否存活，避免误删长耗时任务
+                    {
+                        let journal = serde_json::json!({
+                            "task_type": "auto_memory",
+                            "memory_type": memory_type.name(),
+                            "message_count": message_count,
+                            "started_at": chrono::Utc::now().to_rfc3339(),
+                            "owner_pid": std::process::id(),
+                        });
+                        if let Ok(content) = serde_json::to_string_pretty(&journal) {
+                            if let Err(e) =
+                                crate::fs_util::atomic_write(&auto_journal_path, content.as_bytes())
+                            {
+                                tracing::debug!(
+                                    error = %e,
+                                    memory_type = memory_type.name(),
+                                    "[layer5] 写入 Auto Memory journal 失败"
+                                );
+                            }
+                        }
+                    }
 
-                    // 为每种记忆类型创建独立的异步任务
-                    for memory_type in types {
-                        let provider_pool_for_type = Arc::clone(&provider_pool);
-                        let history_for_type = history_clone.clone();
-                        let config_dir_for_type = config_dir.clone();
-                        let model_for_type = model.clone();
-                        let layer5_config_for_type = layer5_config.clone();
-                        let reload_flag_for_type = Arc::clone(&reload_flag);
-                        let cursor_reload_flag_for_type = Arc::clone(&cursor_reload_flag);
+                    let _handle = tokio::spawn(async move {
+                        // marker 已在 spawn 前原子创建，无需在任务内创建
 
-                        // 获取最后一条用户消息的 UUID（用于游标更新）
-                        let last_user_uuid = history_for_type
-                            .iter()
-                            .rev()
-                            .find(|m| m.role == "user")
-                            .and_then(|m| m.id.clone())
-                            .and_then(|s| uuid::Uuid::parse_str(&s).ok())
-                            .unwrap_or_else(uuid::Uuid::new_v4);
+                        // 创建提取器（会加载持久化的游标状态）
+                        let extractor_config =
+                            crate::auto_memory::AutoMemoryConfig::from(layer5_config_for_type);
+                        let mut extractor =
+                            match crate::auto_memory::AutoMemoryExtractor::with_config(
+                                &config_dir_for_type,
+                                extractor_config,
+                            )
+                            .await
+                            {
+                                Ok(e) => e,
+                                Err(e) => {
+                                    warn!(error = %e, "[layer5] Failed to create AutoMemoryExtractor");
+                                    // 清理 pending 标记和 journal
+                                    let _ = std::fs::remove_file(&auto_marker_path);
+                                    let _ = std::fs::remove_file(&auto_journal_path);
+                                    return;
+                                }
+                            };
 
-                        let message_count = history_for_type.len();
-
-                        let handle = tokio::spawn(async move {
-                            // 创建提取器（会加载持久化的游标状态）
-                            let extractor_config =
-                                crate::auto_memory::AutoMemoryConfig::from(layer5_config_for_type);
-                            let mut extractor =
-                                match crate::auto_memory::AutoMemoryExtractor::with_config(
-                                    &config_dir_for_type,
-                                    extractor_config,
-                                )
-                                .await
-                                {
-                                    Ok(e) => e,
-                                    Err(e) => {
-                                        warn!(error = %e, "[layer5] Failed to create AutoMemoryExtractor");
-                                        return;
-                                    }
-                                };
-
-                            let system_prompt = Arc::new(
+                        let system_prompt = Arc::new(
                                 "你是一个记忆提取助手。请从对话中提取用户偏好、项目信息、反馈和外部资源引用。"
                                     .to_string(),
                             );
 
-                            // 使用 ExtractionParams 和 extract() 方法
-                            // 这样游标状态会被正确更新和保存
-                            let params = crate::auto_memory::ExtractionParams {
-                                provider_pool: provider_pool_for_type,
-                                memory_type,
-                                system_prompt,
-                                model: model_for_type,
-                                messages: history_for_type,
-                                last_message_uuid: last_user_uuid,
-                                message_count,
-                            };
+                        // 使用 ExtractionParams 和 extract() 方法
+                        // 这样游标状态会被正确更新和保存
+                        let params = crate::auto_memory::ExtractionParams {
+                            provider_pool: provider_pool_for_type,
+                            memory_type,
+                            system_prompt,
+                            model: model_for_type,
+                            messages: history_for_type,
+                            last_message_uuid: last_user_uuid,
+                            message_count,
+                        };
 
-                            let result = extractor.extract(params).await;
+                        let result = extractor.extract(params).await;
 
-                            if result.success {
+                        // 清理 pending 标记
+                        // 如果 cursor_save_failed，保留 marker 以便下次重试，
+                        // 避免游标未推进时重复触发提取但 marker 被清除导致无法防重
+                        if !result.success || !result.cursor_save_failed {
+                            let _ = std::fs::remove_file(&auto_marker_path);
+                            let _ = std::fs::remove_file(&auto_journal_path);
+                        } else {
+                            warn!(
+                                memory_type = result.memory_type.name(),
+                                "[layer5] 游标保存失败，保留 pending marker 以便重试"
+                            );
+                        }
+
+                        if result.success {
+                            if result.cursor_save_failed {
+                                // 游标保存失败：记忆文件已更新但游标未推进
+                                // 不设置 reload flag，避免刷新不完整的游标状态
+                                // pending marker 已保留，下次交互会重试提取
+                                warn!(
+                                        memory_type = memory_type.name(),
+                                        "[layer5] Auto Memory 提取完成但游标保存失败，不刷新缓存，等待重试"
+                                    );
+                            } else {
                                 info!(
                                     memory_type = memory_type.name(),
                                     input_tokens = result.input_tokens,
                                     output_tokens = result.output_tokens,
-                                    cursor_save_failed = result.cursor_save_failed,
                                     "[layer5] Auto Memory extraction completed"
                                 );
                                 // 标记需要刷新缓存
@@ -5808,77 +6137,79 @@ impl AgentRuntime {
                                 // 标记需要重新加载游标状态（通知主线程）
                                 cursor_reload_flag_for_type
                                     .store(true, std::sync::atomic::Ordering::Release);
-                            } else {
-                                warn!(
-                                    memory_type = memory_type.name(),
-                                    error = ?result.error,
-                                    "[layer5] Auto Memory extraction failed"
-                                );
                             }
-                        });
-
-                        // 保存任务句柄
-                        if let Some(ms) = self.memory_system.as_mut() {
-                            ms.add_background_task(handle);
+                        } else {
+                            warn!(
+                                memory_type = memory_type.name(),
+                                error = ?result.error,
+                                "[layer5] Auto Memory extraction failed"
+                            );
                         }
-                    }
+                    });
+
+                    // 注意：不将 Auto Memory 提取句柄加入 background_tasks，
+                    // 避免短生命周期 runtime drop 时 abort 导致游标状态无法保存。
+                    // AutoMemoryExtractor::extract() 内部已自行持久化游标状态。
                 }
-                crate::memory_system::PostSamplingAction::Compact => {
-                    // Post-Sampling 中的 Compact - 同步执行压缩
-                    // Compact 应在当前交互结束前同步执行
-                    // 这样下次交互时历史已经是压缩后的状态，用户无感知
+            }
+
+            // 3. Compact（在 spawn 之后执行，确保提取任务已拿到完整历史快照）
+            if actions.compact {
+                // Post-Sampling 中的 Compact - 同步执行压缩
+                // Compact 应在当前交互结束前同步执行
+                // 这样下次交互时历史已经是压缩后的状态，用户无感知
+                info!(
+                    current_tokens,
+                    token_budget = memory_system.config().token_budget,
+                    "[post-sampling] Executing synchronous compact before response delivery"
+                );
+
+                let compact_ctx = CompactContext {
+                    channel: &msg.channel,
+                    chat_id: &msg.chat_id,
+                    account_id: msg.account_id.as_deref(),
+                };
+                if let Err(e) = self
+                    .capture_pre_compress_learning_boundary(&persist_session_key, &history)
+                    .await
+                {
+                    warn!(error = %e, session_key = %persist_session_key, "Ghost learning pre-compress capture failed");
+                }
+                let compact_result = self
+                    .execute_layer4_compact(
+                        &history,
+                        &persist_session_key,
+                        Some(compact_ctx),
+                        true, // is_auto for automatic compact
+                    )
+                    .await;
+                if compact_result.success {
+                    // 压缩成功，替换历史
+                    history.clear();
+                    history.push(ChatMessage::system(&compact_result.to_compact_message()));
+                    history.push(ChatMessage::user("请继续当前任务。"));
+
+                    history.extend(compact_result.recent_messages);
+
                     info!(
-                        current_tokens,
-                        token_budget = memory_system.config().token_budget,
-                        "[post-sampling] Executing synchronous compact before response delivery"
+                        post_compact_tokens = estimate_messages_tokens(&history),
+                        "[post-sampling] Compact completed, history replaced"
                     );
+                    metrics.record_compression();
 
-                    let compact_ctx = CompactContext {
-                        channel: &msg.channel,
-                        chat_id: &msg.chat_id,
-                        account_id: msg.account_id.as_deref(),
-                    };
-                    if let Err(e) = self
-                        .capture_pre_compress_learning_boundary(&session_key, &history)
-                        .await
-                    {
-                        warn!(error = %e, session_key = %session_key, "Ghost learning pre-compress capture failed");
+                    // 清空追踪器
+                    if let Some(ms) = self.memory_system.as_mut() {
+                        ms.file_tracker_mut().clear();
+                        ms.skill_tracker_mut().clear();
+                        // 重置 Session/Auto 增量基线，避免压缩后永远不触发记忆提取
+                        ms.reset_baselines_after_compact(&history);
                     }
-                    let compact_result = self
-                        .execute_layer4_compact(
-                            &history,
-                            &session_key,
-                            Some(compact_ctx),
-                            true, // is_auto for automatic compact
-                        )
-                        .await;
-                    if compact_result.success {
-                        // 压缩成功，替换历史
-                        history.clear();
-                        history.push(ChatMessage::system(&compact_result.to_compact_message()));
-                        history.push(ChatMessage::user("请继续当前任务。"));
-
-                        history.extend(compact_result.recent_messages);
-
-                        info!(
-                            post_compact_tokens = estimate_messages_tokens(&history),
-                            "[post-sampling] Compact completed, history replaced"
-                        );
-                        metrics.record_compression();
-
-                        // 清空追踪器
-                        if let Some(ms) = self.memory_system.as_mut() {
-                            ms.file_tracker_mut().clear();
-                            ms.skill_tracker_mut().clear();
-                        }
-                    } else {
-                        warn!(
-                            error = ?compact_result.error,
-                            "[post-sampling] Compact failed, continuing without compression"
-                        );
-                    }
+                } else {
+                    warn!(
+                        error = ?compact_result.error,
+                        "[post-sampling] Compact failed, continuing without compression"
+                    );
                 }
-                crate::memory_system::PostSamplingAction::None => {}
             }
 
             // 清理已完成的后台任务
@@ -5911,9 +6242,11 @@ impl AgentRuntime {
             }
         }
 
+        // cron 投递场景下 Ghost sync/prefetch 使用 persist_session_key（目标会话），
+        // 确保学习/召回归属到目标会话而非源会话
         if let Some(manager) = self.ghost_memory_lifecycle.as_ref() {
-            manager.sync_all(&msg.content, &delivered_response, &session_key);
-            manager.queue_prefetch_all(&msg.content, &session_key);
+            manager.sync_all(&msg.content, &delivered_response, &persist_session_key);
+            manager.queue_prefetch_all(&msg.content, &persist_session_key);
         }
 
         self.spawn_pending_ghost_background_reviews();

--- a/crates/agent/tests/memory_integration_test.rs
+++ b/crates/agent/tests/memory_integration_test.rs
@@ -6,7 +6,7 @@
 mod tests {
     use blockcell_agent::auto_memory::{ExtractionCursor, ExtractionCursorManager, MemoryType};
     use blockcell_agent::memory_system::{
-        evaluate_memory_hooks, MemorySystem, MemorySystemConfig, PostSamplingAction,
+        evaluate_memory_hooks, MemorySystem, MemorySystemConfig, PostSamplingActions,
     };
     use blockcell_agent::session_memory::{
         should_extract_memory, SessionMemoryConfig, SessionMemoryState,
@@ -71,8 +71,8 @@ mod tests {
 
         let messages = vec![ChatMessage::user("Hello"), ChatMessage::assistant("Hi!")];
 
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
-        assert!(matches!(action, PostSamplingAction::None));
+        let actions = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
+        assert!(actions.is_empty());
     }
 
     /// 测试 Post-Sampling Hook Compact 触发
@@ -94,9 +94,9 @@ mod tests {
         );
 
         let messages = vec![ChatMessage::user("Test")];
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
+        let actions = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
-        assert!(matches!(action, PostSamplingAction::Compact));
+        assert!(actions.compact);
     }
 
     /// 测试 Session Memory 状态更新
@@ -1344,10 +1344,11 @@ _No errors encountered._
 
     /// 测试 PostSamplingAction 优先级
     ///
-    /// 验证 Compact > Session Memory > Auto Memory 的优先级顺序
+    /// 验证设计文档要求的顺序：Session Memory > Auto Memory > Compact
+    /// Layer 3/5 必须在 Layer 4 之前，确保压缩前用完整历史提取
     #[tokio::test]
     async fn test_post_sampling_action_priority() {
-        // Compact 最高优先级
+        // 设计文档：Layer 3/5 先于 Layer 4
         let config = MemorySystemConfig {
             token_budget: 100,
             layer4: Layer4Config {
@@ -1365,7 +1366,7 @@ _No errors encountered._
             "test".to_string(),
         );
 
-        // 创建足够多的消息
+        // 创建足够多的消息（触发 auto memory 和 compact）
         let messages: Vec<ChatMessage> = (0..20)
             .flat_map(|i| {
                 vec![
@@ -1375,11 +1376,15 @@ _No errors encountered._
             })
             .collect();
 
-        // 当 Token 超过阈值时，应返回 Compact 而不是其他 Action
-        let action = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
+        // Auto Memory 应在 Compact 之前触发（设计文档：Layer 3/5 先于 Layer 4）
+        let actions = evaluate_memory_hooks(&mut memory_system, &messages, 100).await;
 
-        // Compact 优先级最高
-        assert!(matches!(action, PostSamplingAction::Compact));
+        // Auto Memory 和 Compact 可以同时触发
+        assert!(
+            !actions.auto_memory_types.is_empty(),
+            "Auto Memory 应被触发，实际: {:?}",
+            actions
+        );
     }
 
     /// 测试 Layer 各层 Token 预算约束

--- a/crates/core/src/config/memory.rs
+++ b/crates/core/src/config/memory.rs
@@ -259,6 +259,10 @@ pub struct Layer5Config {
     /// 内容变化阈值（字符数），内容变化需超过此值才触发提取
     #[serde(default = "default_l5_content_change_threshold")]
     pub content_change_threshold: usize,
+    /// 后台提取 pending marker 过期阈值（毫秒）
+    /// 独立于 Layer 3 的 extraction_stale_threshold_ms，避免长任务被短阈值误判
+    #[serde(default = "default_l5_extraction_stale_threshold_ms")]
+    pub extraction_stale_threshold_ms: u64,
 }
 
 fn default_l5_min_messages() -> usize {
@@ -279,6 +283,9 @@ fn default_l5_time_cooldown_secs() -> u64 {
 fn default_l5_content_change_threshold() -> usize {
     500
 }
+fn default_l5_extraction_stale_threshold_ms() -> u64 {
+    300_000 // 5 分钟，比 Layer 3 的 1 分钟更长，适合长任务
+}
 
 impl Default for Layer5Config {
     fn default() -> Self {
@@ -289,6 +296,7 @@ impl Default for Layer5Config {
             injection_max_tokens: 4_000,
             extraction_time_cooldown_secs: 300,
             content_change_threshold: 500,
+            extraction_stale_threshold_ms: 300_000,
         }
     }
 }

--- a/crates/scheduler/src/consolidator.rs
+++ b/crates/scheduler/src/consolidator.rs
@@ -882,6 +882,123 @@ impl DreamConsolidator {
             if entry.file_type().await.map(|t| !t.is_dir()).unwrap_or(true) {
                 continue;
             }
+            // 避让正在提取的 Session Memory：
+            // 如果目录下存在 .extraction_pending 标记，说明 Layer 3 正在更新 memory.md，
+            // 此时读取可能得到旧内容或写入中的半截内容，应跳过。
+            // 但如果标记已过期（超过 stale 阈值），说明提取任务已崩溃或被遗弃，
+            // 清理过期标记和对应 journal 后继续读取当前 memory.md。
+            let pending_marker = entry.path().join(".extraction_pending");
+            if fs::try_exists(&pending_marker).await.unwrap_or(false) {
+                // stale 阈值：10x Layer3 默认 extraction_stale_threshold (60s * 10 = 600s)
+                // 此常量与 agent 侧 Layer3Config::extraction_stale_threshold_ms (默认 60000ms) 关联。
+                // scheduler crate 无法直接引用 agent 配置，故使用关联常量。
+                // 10x 裕量确保：即使 LLM 提取耗时较长，也不会被 Dream 误清。
+                const EXTRACTION_STALE_THRESHOLD_SECS: u64 = 600;
+                let is_mtime_stale = fs::metadata(&pending_marker)
+                    .await
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|mtime| mtime.elapsed().ok())
+                    .map(|elapsed| elapsed.as_secs() >= EXTRACTION_STALE_THRESHOLD_SECS)
+                    .unwrap_or(true); // 无法读取 mtime 视为过期
+
+                if is_mtime_stale {
+                    // marker 已过期，但在清理前先检查 journal 的 owner_pid/started_at
+                    // 避免 Dream 误删长耗时任务的 marker
+                    let journal_path = entry.path().join(".extraction_journal");
+                    let should_clean = if journal_path.exists() {
+                        // 尝试读取 journal 判断任务是否仍在运行
+                        match fs::read_to_string(&journal_path).await {
+                            Ok(content) => {
+                                if let Ok(journal) =
+                                    serde_json::from_str::<serde_json::Value>(&content)
+                                {
+                                    // 检查 owner_pid：如果进程仍存活，任务可能在运行
+                                    if let Some(owner_pid) =
+                                        journal.get("owner_pid").and_then(|v| v.as_u64())
+                                    {
+                                        let pid = owner_pid as u32;
+                                        if pid == std::process::id() {
+                                            // 同一进程：journal 不是孤儿
+                                            tracing::debug!(
+                                                session_dir = %entry.path().display(),
+                                                "[dream] journal owner 是当前进程，保留 marker"
+                                            );
+                                            false
+                                        } else {
+                                            // Unix: 检查 /proc/{pid} 是否存在
+                                            #[cfg(unix)]
+                                            {
+                                                if std::path::Path::new(&format!("/proc/{}", pid))
+                                                    .exists()
+                                                {
+                                                    tracing::debug!(
+                                                        session_dir = %entry.path().display(),
+                                                        pid,
+                                                        "[dream] journal owner 进程仍存活，保留 marker"
+                                                    );
+                                                    false
+                                                } else {
+                                                    // 进程已死，使用 started_at + 3x 阈值做最终判断
+                                                    is_journal_started_at_expired(
+                                                        &journal,
+                                                        EXTRACTION_STALE_THRESHOLD_SECS * 3,
+                                                    )
+                                                }
+                                            }
+                                            #[cfg(not(unix))]
+                                            {
+                                                // Windows 下无法无依赖检查 PID 存活，
+                                                // 使用 started_at + 3x 阈值做保守判断
+                                                let _ = pid;
+                                                is_journal_started_at_expired(
+                                                    &journal,
+                                                    EXTRACTION_STALE_THRESHOLD_SECS * 3,
+                                                )
+                                            }
+                                        }
+                                    } else {
+                                        // 无 owner_pid（旧格式），使用 started_at + 3x 阈值
+                                        is_journal_started_at_expired(
+                                            &journal,
+                                            EXTRACTION_STALE_THRESHOLD_SECS * 3,
+                                        )
+                                    }
+                                } else {
+                                    true // 无法解析 JSON，清理
+                                }
+                            }
+                            Err(_) => true, // 无法读取 journal，清理
+                        }
+                    } else {
+                        true // 无 journal，清理
+                    };
+
+                    if should_clean {
+                        tracing::warn!(
+                            session_dir = %entry.path().display(),
+                            "[dream] 清理过期的 extraction pending marker 和 journal（journal 确认可清理）"
+                        );
+                        let _ = fs::remove_file(&pending_marker).await;
+                        if journal_path.exists() {
+                            let _ = fs::remove_file(&journal_path).await;
+                        }
+                        // 清理后继续读取当前 memory.md
+                    } else {
+                        tracing::debug!(
+                            session_dir = %entry.path().display(),
+                            "[dream] marker 虽然过期但 journal 显示任务仍在运行，跳过"
+                        );
+                        continue;
+                    }
+                } else {
+                    tracing::debug!(
+                        session_dir = %entry.path().display(),
+                        "[dream] 跳过正在提取 Session Memory 的会话（marker 未过期）"
+                    );
+                    continue;
+                }
+            }
             let memory_file = entry.path().join("memory.md");
             if fs::try_exists(&memory_file).await? {
                 if let Ok(metadata) = fs::metadata(&memory_file).await {
@@ -932,6 +1049,9 @@ impl DreamConsolidator {
     }
 
     /// 从 session memory 内容中提取信号
+    ///
+    /// 支持一级标题 (`# `) 和二级标题 (`## `)，与 Session Memory 10-section 模板兼容。
+    /// 同时向后兼容旧格式（仅含二级标题的文件）。
     fn extract_signals_from_memory(
         &self,
         content: &str,
@@ -939,23 +1059,29 @@ impl DreamConsolidator {
     ) -> Vec<GatheredSignal> {
         let mut signals = Vec::new();
 
-        // 按章节分割
-        for section in content.split("\n## ") {
+        // 按 markdown 标题分割：支持 `# `（一级）和 `## `（二级）
+        // 使用行扫描方式，识别每行开头的 heading marker
+        let sections = split_by_markdown_headings(content);
+
+        for section in &sections {
             let section = section.trim();
             if section.is_empty() {
                 continue;
             }
 
-            // 提取章节标题
+            // 提取章节标题（第一行，去除 heading marker）
             let title_end = section.find('\n').unwrap_or(section.len());
-            let title = section[..title_end].trim();
+            let raw_title = section[..title_end].trim();
+            // 去除 heading marker（`# ` 或 `## `）
+            let title = raw_title
+                .trim_start_matches("# ")
+                .trim_start_matches("## ")
+                .trim();
 
             // 提取章节内容（跳过标题行和换行符）
             let section_content = if title_end < section.len() {
-                // 有换行符，从换行符后开始提取
                 section[title_end..].trim()
             } else {
-                // 没有换行符，只有标题，无内容
                 ""
             };
 
@@ -978,22 +1104,40 @@ impl DreamConsolidator {
     }
 
     /// 计算信号的重要性分数 (0-10)
+    ///
+    /// 基于 Session Memory 10-section 模板的实际章节标题：
+    /// - Session Title, Current State, Task specification, Files and Functions,
+    ///   Workflow, Errors & Corrections, Codebase and System Documentation,
+    ///   Learnings, Key results, Worklog
     fn calculate_signal_importance(&self, title: &str, content: &str) -> u8 {
-        // 高重要性章节
-        let high_priority = ["Current State", "Errors & Corrections", "User Request"];
-        // 中重要性章节
-        let medium_priority = ["Key Files", "Pending Tasks", "Important Context"];
-        // 低重要性章节
-        let low_priority = ["Work Log", "Session Info"];
+        // 归一化标题用于匹配（trim + 大小写不敏感）
+        let normalized = title.trim().to_lowercase();
 
-        if high_priority.iter().any(|t| title.contains(t)) {
+        // 高重要性章节：直接影响后续工作的关键信息
+        let high_priority = [
+            "current state",
+            "errors & corrections",
+            "errors and corrections",
+        ];
+        // 中重要性章节：任务定义、文件、关键结果
+        let medium_priority = [
+            "task specification",
+            "files and functions",
+            "key results",
+            "decisions & preferences",
+            "artifacts & files",
+        ];
+        // 低重要性章节：工作流和工作日志
+        let low_priority = ["workflow", "worklog", "work log"];
+
+        if high_priority.iter().any(|t| normalized.contains(t)) {
             8
-        } else if medium_priority.iter().any(|t| title.contains(t)) {
+        } else if medium_priority.iter().any(|t| normalized.contains(t)) {
             5
-        } else if low_priority.iter().any(|t| title.contains(t)) {
+        } else if low_priority.iter().any(|t| normalized.contains(t)) {
             2
         } else {
-            // 根据内容长度和关键词判断
+            // 根据内容长度判断
             let content_len = content.len();
             if content_len > 500 {
                 4
@@ -1059,6 +1203,22 @@ impl DreamConsolidator {
 
         match result {
             Ok(agent_result) => {
+                // 检查工具调用失败：与 Auto Memory / Session Memory 保持一致
+                // had_tool_error 为 true 时不应视为 consolidation 成功
+                if agent_result.had_tool_error {
+                    // 熔断器记录失败
+                    cb.record_failure();
+
+                    tracing::error!(
+                        session_ids = ?agent_result.files_modified,
+                        response = ?agent_result.final_content,
+                        "[dream] Forked Agent 工具调用失败，consolidation 标记为失败"
+                    );
+                    return Err(DreamError::ConsolidationFailed(
+                        "Forked Agent 工具调用失败 (had_tool_error=true)".to_string(),
+                    ));
+                }
+
                 // 熔断器记录成功
                 cb.record_success();
 
@@ -1496,6 +1656,147 @@ pub enum DreamError {
 
     #[error("Circuit breaker is open, dream consolidation blocked")]
     CircuitBreakerOpen,
+}
+
+/// 按 markdown 标题分割内容（支持 `# ` 和 `## `）
+///
+/// 返回 Vec，每个元素是一个 section（包含标题行和内容）。
+/// 第一个标题之前的内容会被忽略，因为 session memory 模板以标题开头。
+/// 维护 fenced code block 状态，避免误切 ``` 围栏内的 `#` 标题。
+fn split_by_markdown_headings(content: &str) -> Vec<&str> {
+    let mut sections = Vec::new();
+    let mut section_start: Option<usize> = None;
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+    let mut pos = 0;
+    // 追踪 fenced code block 状态，避免误切围栏内的 `#` 标题
+    let mut in_fenced_code = false;
+    // 记录当前 fence 的长度（3 或更多反引号），只有匹配长度的 fence 才能关闭
+    let mut fence_len: usize = 0;
+
+    while pos < len {
+        // pos 始终在行开头（或 pos=0）
+        // 查找当前行的结束位置
+        let line_end = bytes[pos..]
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| pos + p)
+            .unwrap_or(len);
+
+        // 检查当前行是否是 fence 开关（``` 或 ~~~）
+        let line_bytes = &bytes[pos..line_end];
+        let line = std::str::from_utf8(line_bytes).unwrap_or("");
+        let trimmed = line.trim();
+
+        // 检测 fence 行：行首（允许最多 3 个空格缩进）由 >=3 个 ` 或 ~ 组成
+        if !in_fenced_code {
+            // 尝试匹配 fence 开始
+            let fence_char = if trimmed.starts_with("```") {
+                b'`'
+            } else if trimmed.starts_with("~~~") {
+                b'~'
+            } else {
+                0
+            };
+            if fence_char != 0 {
+                let fl = trimmed.bytes().take_while(|&c| c == fence_char).count();
+                // fence 后面必须跟空白或行尾才算有效 fence
+                if fl >= 3
+                    && trimmed
+                        .as_bytes()
+                        .get(fl)
+                        .copied()
+                        .is_none_or(|c| c.is_ascii_whitespace())
+                {
+                    in_fenced_code = true;
+                    fence_len = fl;
+                }
+            }
+        } else {
+            // 尝试匹配 fence 结束：只有相同字符、相同或更长长度才能关闭
+            let fence_char = if trimmed.starts_with(&"`".repeat(fence_len)) {
+                b'`'
+            } else if trimmed.starts_with(&"~".repeat(fence_len)) {
+                b'~'
+            } else {
+                0
+            };
+            if fence_char != 0 {
+                let fl = trimmed.bytes().take_while(|&c| c == fence_char).count();
+                if fl >= fence_len
+                    && trimmed
+                        .as_bytes()
+                        .get(fl)
+                        .copied()
+                        .is_none_or(|c| c.is_ascii_whitespace())
+                {
+                    in_fenced_code = false;
+                    fence_len = 0;
+                }
+            }
+        }
+
+        // 检查当前行是否是标题（仅在非 fenced code block 内判断）
+        if !in_fenced_code {
+            let is_h1 = trimmed.starts_with("# ") && !trimmed.starts_with("## ");
+            let is_h2 = trimmed.starts_with("## ") && !trimmed.starts_with("### ");
+
+            if is_h1 || is_h2 {
+                // 结束前一个 section
+                if let Some(start) = section_start {
+                    let end = if pos > 0 && bytes[pos - 1] == b'\n' {
+                        pos - 1 // 去掉前导换行符
+                    } else {
+                        pos
+                    };
+                    if end > start {
+                        sections.push(&content[start..end]);
+                    }
+                }
+                section_start = Some(pos);
+            }
+        }
+
+        // 移动到下一行
+        pos = if line_end < len { line_end + 1 } else { len };
+    }
+
+    // 处理最后一个 section
+    if let Some(start) = section_start {
+        if start < len {
+            let remaining = content[start..].trim_end();
+            if !remaining.is_empty() {
+                sections.push(&content[start..]);
+            }
+        }
+    } else if !content.trim().is_empty() {
+        // 没有找到任何标题，整个内容作为一个 section（向后兼容旧格式）
+        sections.push(content);
+    }
+
+    sections
+}
+
+/// 检查 journal 的 started_at 字段是否已超过指定阈值
+///
+/// 当 owner 进程已死或无法判断时，使用 started_at 时间做最终过期判断。
+/// 阈值建议使用 3x 正常 stale 阈值（与 agent 侧 is_journal_stale 一致）。
+fn is_journal_started_at_expired(journal: &serde_json::Value, threshold_secs: u64) -> bool {
+    let started_at_str = journal
+        .get("started_at")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let started_at = match chrono::DateTime::parse_from_rfc3339(started_at_str) {
+        Ok(dt) => dt,
+        Err(_) => return true, // 无法解析视为过期
+    };
+    let elapsed = chrono::Utc::now()
+        .signed_duration_since(started_at.with_timezone(&chrono::Utc))
+        .num_seconds();
+    match elapsed {
+        e if e >= 0 => (e as u64) >= threshold_secs,
+        _ => false, // 未来时间戳，不视为过期
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage/src/session.rs
+++ b/crates/storage/src/session.rs
@@ -62,6 +62,36 @@ impl SessionStore {
         Ok(messages)
     }
 
+    /// 读取 session 文件外层的时间戳（created_at, updated_at）
+    ///
+    /// 与 load_metadata() 不同，此方法返回的是 metadata 行外层的 created_at 和 updated_at，
+    /// 而非 metadata 子对象内部的内容。Layer 2 时间触发轻量压缩需要 updated_at 来判断
+    /// 会话是否长时间未更新。
+    pub fn load_timestamps(&self, session_key: &str) -> Result<(Option<String>, Option<String>)> {
+        let path = self.paths.session_file(session_key);
+
+        if !path.exists() {
+            return Ok((None, None));
+        }
+
+        Ok(self
+            .read_metadata_line(&path)
+            .map(|(created_at, _)| (Some(created_at), self.read_updated_at(&path)))
+            .unwrap_or((None, None)))
+    }
+
+    /// 从 session 文件第一行读取 updated_at 字段
+    fn read_updated_at(&self, path: &std::path::Path) -> Option<String> {
+        let file = File::open(path).ok()?;
+        let mut reader = BufReader::new(file);
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line).ok()?;
+        let line: serde_json::Value = serde_json::from_str(first_line.trim()).ok()?;
+        line.get("updated_at")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    }
+
     pub fn load_metadata(&self, session_key: &str) -> Result<Value> {
         let path = self.paths.session_file(session_key);
 
@@ -204,8 +234,15 @@ impl SessionStore {
 
     /// Clear session history by deleting the session file.
     /// Returns true if the file existed and was deleted, false if it didn't exist.
+    /// 同时删除关联的 sidecar marker 文件（如 .dream_counted），保持生命周期一致。
     pub fn clear(&self, session_key: &str) -> Result<bool> {
         let path = self.paths.session_file(session_key);
+
+        // 同步删除 sidecar marker 文件，避免会话清理后同 key 复用时 marker 残留
+        let marker_path = path.with_extension("dream_counted");
+        if marker_path.exists() {
+            let _ = std::fs::remove_file(&marker_path);
+        }
 
         if path.exists() {
             std::fs::remove_file(&path)?;
@@ -213,6 +250,68 @@ impl SessionStore {
             Ok(true)
         } else {
             Ok(false)
+        }
+    }
+
+    /// 原子标记会话已被 Dream 计数，使用独立 marker 文件 + create_new 实现并发安全。
+    ///
+    /// 返回 true 表示本次成功标记（应递增计数），false 表示已被其他 runtime 标记过。
+    /// 解决 metadata save 的 TOCTOU 竞态：两个 runtime 可能同时读到 dream_counted=false，
+    /// 都执行 save_with_metadata（File::create 覆盖写），导致重复递增。
+    /// create_new(true) 保证只有一个调用者能成功创建文件。
+    ///
+    /// 迁移兼容：旧版本在 metadata 中存储 dream_counted=true（无 sidecar marker）。
+    /// 首次遇到旧会话时，检测 metadata 中的标记，自动创建 sidecar 并返回 false（不重复计数）。
+    pub fn mark_dream_counted(&self, session_key: &str) -> bool {
+        let path = self.paths.session_file(session_key);
+        let marker_path = path.with_extension("dream_counted");
+
+        if let Some(parent) = marker_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        // create_new(true): 文件已存在返回 Err，只有一个调用者能成功
+        let created = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&marker_path)
+            .is_ok();
+
+        if !created {
+            // sidecar marker 已存在，说明已被计数过
+            return false;
+        }
+
+        // sidecar 创建成功，但需要检查旧 metadata 是否已有 dream_counted=true
+        // （从旧版本迁移的会话：metadata 有标记但无 sidecar）
+        if let Ok(metadata) = self.load_metadata(session_key) {
+            if metadata
+                .get("dream_counted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                // 旧版本已计过数，不重复计数
+                debug!(
+                    session_key = %session_key,
+                    "[dream] 检测到旧版本 dream_counted metadata，sidecar 已创建但不重复计数"
+                );
+                return false;
+            }
+        }
+
+        // 全新标记，应递增计数
+        true
+    }
+
+    /// 清除 dream 计数 sidecar marker
+    ///
+    /// 当 `increment_dream_session_count` 失败时调用，
+    /// 删除 marker 以便下次交互时重试递增，避免永久漏计。
+    pub fn clear_dream_counted_marker(&self, session_key: &str) {
+        let path = self.paths.session_file(session_key);
+        let marker_path = path.with_extension("dream_counted");
+        if marker_path.exists() {
+            let _ = std::fs::remove_file(&marker_path);
         }
     }
 


### PR DESCRIPTION
问题汇总：
1. [P2] Session Memory 触发时跳过同轮 Auto Memory
2. [P2] Compact 后未重置 Session/Auto 增量基线，导致记忆提取长期不触发
3. [P2] pending marker 过期检查绕过 journal owner_pid 保护
4. [P3] runtime 手写 Auto Memory journal 缺少 owner_pid
5. [P3] Dream 计数 marker 与递增非原子，失败会永久漏计
6. [P3] Dream consolidator stale 判断使用硬编码 600s

修改：

- 将 PostSamplingAction enum 改为 PostSamplingActions struct， 支持同一轮返回 session+auto+compact 组合动作，消除 early return
导致 Session/Auto/Compact 同时到期时 Auto Memory 被跳过的问题

- 新增 MemorySystem::reset_baselines_after_compact()，在 compact 成功后 用压缩后历史重置 tokens_at_last_extraction 和 cursor last_message_count， 避免 saturating_sub 恒为 0 导致后续提取永远不触发

- should_extract_session_memory / has_active_auto_memory_pending 在 marker 过期时先调用 is_journal_stale() 检查 journal 的 owner_pid， 进程仍存活则保留 marker，避免误删长耗时任务的标记

- runtime.rs Auto Memory journal 写入补齐 owner_pid 字段， 使 Layer 5 的 owner_pid 保护机制实际生效

- increment_dream_session_count 改为返回 Result， 递增失败时清除 sidecar marker 允许重试，避免永久漏计

- consolidator stale 检查改为读取 .extraction_journal 的 owner_pid 和 started_at（3x 阈值），不再仅依赖 marker mtime 硬编码 600s